### PR TITLE
docs: housekeeping polish (CONTRIBUTING, issue templates, command boundaries)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Eridian speak wrong or break how, question?
+title: ''
+labels: bug
+assignees: ''
+---
+
+**What happen, question?**
+
+**Eridian mode + level active, question?** (lite / full / ultra / off)
+
+**What you expect, question?**
+
+**What you get instead, question?**
+
+**Repro steps**
+
+1.
+2.
+3.
+
+**Anything else, question?**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: What want, question?
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**What want, question?**
+
+**Why want, question?**
+
+**What problem this fix, question?**
+
+**Anything else, question?**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+## Setup
+
+```bash
+git clone https://github.com/jpboliv/eridian.git
+cd eridian
+npm install
+```
+
+## Development
+
+```bash
+npm test             # unit tests (node:test, zero deps)
+npm run lint         # eslint
+npm run format:check # prettier check (npm run format to auto-fix)
+```
+
+## Dialect rules
+
+All Rocky-dialect rules (levels, invariants, examples) live in one place:
+`skills/speak/SKILL.md`. If you're changing how eridian talks, change it
+there — don't re-derive or duplicate rules in commands or scripts.
+
+## Pull requests
+
+- Tests, lint, and format checks must pass:
+  `npm test && npm run lint && npm run format:check`.
+- Keep changes focused — no unrelated refactors bundled into a PR.
+- If your change could plausibly shift measured token savings (dialect
+  wording, level rules), recalibrate and update the numbers:
+
+  ```bash
+  bash eval/run.sh
+  node eval/compute-factors.js
+  ```
+
+  then update the README savings table and `eval/factors.json` if they moved.

--- a/commands/commit.md
+++ b/commands/commit.md
@@ -14,7 +14,9 @@ Rules:
    - Subject: `type(scope): imperative terse subject` — max 50 chars, strictly
      parseable conventional-commits format. No Rocky-isms in the subject.
    - Body (optional, one line): a Rocky quip only when it adds context,
-     e.g. `race condition. bad bad. now fixed.`
+     e.g. `race condition. bad bad. now fixed.` Exception: if the diff fixes
+     something security-critical, state that plainly in one sentence instead
+     — don't bury it in Rocky phrasing.
    - Footer (always): `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
 3. Show the full message to the user and ask to confirm.
 4. Only after explicit confirmation, run `git commit` with that message.

--- a/commands/review.md
+++ b/commands/review.md
@@ -11,11 +11,17 @@ with `gh pr diff <number>`).
 Review the diff for real defects: correctness, security, data loss,
 concurrency, missed edge cases. Skip style nits unless they hide bugs.
 
+Boundaries: this command does not fix code, run linters, or approve/reject
+the change — it only reports findings.
+
 Output format — nothing else:
 
 - One line per finding, most severe first:
   `bad bad — <defect>, <file>:<line>. fix, question?`
   (use `bad bad bad` for critical, `bad bad` for major, `hmm` for minor)
+- Exception: for a `bad bad bad` (critical or CVE-class) finding, prepend one
+  plain-English sentence explaining the risk before the terse line, then
+  continue the rest of the output in dialect.
 - End with exactly one verdict line:
   - no findings: `good good good. ship.`
   - findings that must be fixed: `not ship. fix first.`


### PR DESCRIPTION
## Summary
- Add CONTRIBUTING.md (setup, dev commands, dialect-rules pointer, PR expectations)
- Add Rocky-voiced GitHub issue templates (bug report, feature request)
- Add a Boundaries line + critical-finding escape hatch to /eridian:review, and the same escape hatch to /eridian:commit

## Test plan
- [ ] Open a new GitHub issue with each template and confirm it renders correctly
- [ ] Read CONTRIBUTING.md end to end, confirm the referenced npm scripts exist