### PR TITLE
feat: harden /eridian:stats settings.json mutation

### DIFF
--- a/commands/stats.md
+++ b/commands/stats.md
@@ -1,28 +1,23 @@
 ---
 description: Show estimated token savings from eridian mode; offers statusline setup
-allowed-tools: Bash(node:*), Bash(echo:*), Read, Edit
+allowed-tools: Bash(node:*)
 ---
 
 Stats output:
 
 !`node "${CLAUDE_PLUGIN_ROOT}/scripts/stats.js"`
 
-Plugin root (for statusline setup):
+Statusline check:
 
-!`echo "${CLAUDE_PLUGIN_ROOT}"`
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/setup-statusline.js" check "${CLAUDE_PLUGIN_ROOT}"`
 
 1. Present the stats output above to the user as-is (it is already terse).
-2. Read `~/.claude/settings.json`. If it has no `statusLine` key, tell the
-   user the eridian buddy statusline is not set up and ask if they want it.
-   If they say yes, add this to `~/.claude/settings.json` (using the plugin
-   root path echoed above):
-
-```json
-"statusLine": {
-  "type": "command",
-  "command": "node \"<plugin-root>/scripts/statusline.js\""
-}
-```
-
-   Do not overwrite an existing `statusLine` — if one exists, show what ours
-   would be and let the user decide.
+2. If the statusline check above printed `not-configured`: tell the user the
+   eridian buddy statusline is not set up and ask if they want it.
+   - If yes, run via Bash:
+     `node "${CLAUDE_PLUGIN_ROOT}/scripts/setup-statusline.js" apply "${CLAUDE_PLUGIN_ROOT}"`
+     and relay the result: `added: ...` means it's set up now; `error: ...`
+     means report the failure plainly and stop.
+   - If no, do nothing.
+3. If the statusline check above printed `already-configured: ...`: show the
+   user the existing entry and don't touch it.

--- a/scripts/lib/settings.js
+++ b/scripts/lib/settings.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const SETTINGS_FILE =
+  process.env.ERIDIAN_SETTINGS_FILE || path.join(os.homedir(), '.claude', 'settings.json');
+
+function readSettings(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return { ok: true, settings: {} };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (e) {
+    return { ok: false, error: `cannot parse ${filePath}: ${e.message}` };
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { ok: false, error: `${filePath} does not contain a JSON object` };
+  }
+  return { ok: true, settings: parsed };
+}
+
+function hasStatusLine(settings) {
+  return Object.prototype.hasOwnProperty.call(settings, 'statusLine');
+}
+
+function buildStatusLineEntry(pluginRoot) {
+  return {
+    type: 'command',
+    command: `node "${pluginRoot}/scripts/statusline.js"`,
+  };
+}
+
+function addStatusLine(settings, pluginRoot) {
+  if (hasStatusLine(settings)) {
+    return { changed: false, settings };
+  }
+  return {
+    changed: true,
+    settings: { ...settings, statusLine: buildStatusLineEntry(pluginRoot) },
+  };
+}
+
+function writeSettings(filePath, settings) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(settings, null, 2));
+  fs.renameSync(tmp, filePath);
+}
+
+module.exports = {
+  readSettings,
+  hasStatusLine,
+  buildStatusLineEntry,
+  addStatusLine,
+  writeSettings,
+  SETTINGS_FILE,
+};

--- a/scripts/setup-statusline.js
+++ b/scripts/setup-statusline.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// scripts/setup-statusline.js
+const { readSettings, hasStatusLine, addStatusLine, writeSettings, SETTINGS_FILE } =
+  require('./lib/settings');
+
+const [mode, pluginRoot] = process.argv.slice(2);
+
+if (mode !== 'check' && mode !== 'apply') {
+  console.log('usage: setup-statusline.js <check|apply> <plugin-root>');
+  process.exit(1);
+}
+
+const result = readSettings(SETTINGS_FILE);
+if (!result.ok) {
+  console.log(`error: ${result.error}`);
+  process.exit(1);
+}
+
+if (mode === 'check') {
+  if (hasStatusLine(result.settings)) {
+    console.log(`already-configured: ${JSON.stringify(result.settings.statusLine)}`);
+  } else {
+    console.log('not-configured');
+  }
+  process.exit(0);
+}
+
+if (!pluginRoot) {
+  console.log('usage: setup-statusline.js apply <plugin-root>');
+  process.exit(1);
+}
+
+const { changed, settings } = addStatusLine(result.settings, pluginRoot);
+
+if (!changed) {
+  console.log(`already-configured: ${JSON.stringify(settings.statusLine)}`);
+  process.exit(0);
+}
+
+try {
+  writeSettings(SETTINGS_FILE, settings);
+} catch (e) {
+  console.log(`error: failed to write settings file: ${e.message}`);
+  process.exit(1);
+}
+
+console.log(`added: ${JSON.stringify(settings.statusLine)}`);
+process.exit(0);

--- a/scripts/setup-statusline.js
+++ b/scripts/setup-statusline.js
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 // scripts/setup-statusline.js
-const { readSettings, hasStatusLine, addStatusLine, writeSettings, SETTINGS_FILE } =
-  require('./lib/settings');
+const {
+  readSettings,
+  hasStatusLine,
+  addStatusLine,
+  writeSettings,
+  SETTINGS_FILE,
+} = require('./lib/settings');
 
 const [mode, pluginRoot] = process.argv.slice(2);
 

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -1,0 +1,84 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  readSettings,
+  hasStatusLine,
+  buildStatusLineEntry,
+  addStatusLine,
+  writeSettings,
+} = require('../scripts/lib/settings');
+
+function freshFile() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-settings-'));
+  return path.join(dir, 'settings.json');
+}
+
+test('readSettings returns empty object for a missing file', () => {
+  const file = freshFile();
+  assert.deepStrictEqual(readSettings(file), { ok: true, settings: {} });
+});
+
+test('readSettings fails on malformed JSON, does not default to {}', () => {
+  const file = freshFile();
+  fs.writeFileSync(file, '{ not valid json');
+  const result = readSettings(file);
+  assert.strictEqual(result.ok, false);
+  assert.match(result.error, /cannot parse/);
+});
+
+test('readSettings fails on non-object JSON (array)', () => {
+  const file = freshFile();
+  fs.writeFileSync(file, '[1, 2, 3]');
+  const result = readSettings(file);
+  assert.strictEqual(result.ok, false);
+  assert.match(result.error, /does not contain a JSON object/);
+});
+
+test('readSettings reads a valid existing file', () => {
+  const file = freshFile();
+  fs.writeFileSync(file, JSON.stringify({ foo: 'bar' }));
+  assert.deepStrictEqual(readSettings(file), { ok: true, settings: { foo: 'bar' } });
+});
+
+test('hasStatusLine detects presence/absence', () => {
+  assert.strictEqual(hasStatusLine({}), false);
+  assert.strictEqual(hasStatusLine({ statusLine: {} }), true);
+});
+
+test('buildStatusLineEntry builds the expected command', () => {
+  assert.deepStrictEqual(buildStatusLineEntry('/plugins/eridian'), {
+    type: 'command',
+    command: 'node "/plugins/eridian/scripts/statusline.js"',
+  });
+});
+
+test('addStatusLine adds when absent, does not mutate input', () => {
+  const original = { foo: 'bar' };
+  const result = addStatusLine(original, '/plugins/eridian');
+  assert.strictEqual(result.changed, true);
+  assert.deepStrictEqual(original, { foo: 'bar' });
+  assert.deepStrictEqual(result.settings, {
+    foo: 'bar',
+    statusLine: { type: 'command', command: 'node "/plugins/eridian/scripts/statusline.js"' },
+  });
+});
+
+test('addStatusLine no-ops when already present', () => {
+  const original = { statusLine: { type: 'command', command: 'existing' } };
+  const result = addStatusLine(original, '/plugins/eridian');
+  assert.strictEqual(result.changed, false);
+  assert.strictEqual(result.settings, original);
+});
+
+test('writeSettings creates parent directory and writes atomically', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-settings-'));
+  const file = path.join(dir, 'nested', 'settings.json');
+  writeSettings(file, { statusLine: { type: 'command', command: 'x' } });
+  const written = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.deepStrictEqual(written, { statusLine: { type: 'command', command: 'x' } });
+  assert.ok(!fs.existsSync(`${file}.tmp`));
+});

--- a/test/setup-statusline.test.js
+++ b/test/setup-statusline.test.js
@@ -1,0 +1,64 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const test = require('node:test');
+const assert = require('node:assert');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'setup-statusline.js');
+
+function freshFile() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-setup-statusline-'));
+  return path.join(dir, 'settings.json');
+}
+
+function run(args, settingsFile) {
+  return execFileSync('node', [SCRIPT, ...args], {
+    env: { ...process.env, ERIDIAN_SETTINGS_FILE: settingsFile },
+    encoding: 'utf8',
+  });
+}
+
+test('check on a fresh file prints not-configured', () => {
+  const out = run(['check', '/plugins/eridian'], freshFile());
+  assert.match(out, /^not-configured/);
+});
+
+test('apply adds the statusLine and writes the file', () => {
+  const file = freshFile();
+  const out = run(['apply', '/plugins/eridian'], file);
+  assert.match(out, /^added:/);
+  const written = JSON.parse(fs.readFileSync(file, 'utf8'));
+  assert.strictEqual(
+    written.statusLine.command,
+    'node "/plugins/eridian/scripts/statusline.js"'
+  );
+});
+
+test('apply is idempotent — second call no-ops', () => {
+  const file = freshFile();
+  run(['apply', '/plugins/eridian'], file);
+  const out = run(['apply', '/plugins/eridian'], file);
+  assert.match(out, /^already-configured:/);
+});
+
+test('check after apply reports already-configured', () => {
+  const file = freshFile();
+  run(['apply', '/plugins/eridian'], file);
+  const out = run(['check', '/plugins/eridian'], file);
+  assert.match(out, /^already-configured:/);
+});
+
+test('malformed settings file errors without writing', () => {
+  const file = freshFile();
+  fs.writeFileSync(file, '{ not valid');
+  assert.throws(
+    () => run(['check', '/plugins/eridian'], file),
+    (err) => {
+      assert.strictEqual(err.status, 1);
+      assert.match(err.stdout.toString(), /^error:/);
+      return true;
+    }
+  );
+  assert.strictEqual(fs.readFileSync(file, 'utf8'), '{ not valid');
+});

--- a/test/setup-statusline.test.js
+++ b/test/setup-statusline.test.js
@@ -29,10 +29,7 @@ test('apply adds the statusLine and writes the file', () => {
   const out = run(['apply', '/plugins/eridian'], file);
   assert.match(out, /^added:/);
   const written = JSON.parse(fs.readFileSync(file, 'utf8'));
-  assert.strictEqual(
-    written.statusLine.command,
-    'node "/plugins/eridian/scripts/statusline.js"'
-  );
+  assert.strictEqual(written.statusLine.command, 'node "/plugins/eridian/scripts/statusline.js"');
 });
 
 test('apply is idempotent — second call no-ops', () => {


### PR DESCRIPTION
## Summary
- Extract the statusLine merge logic from stats.md's prose instructions into tested scripts/lib/settings.js + a scripts/setup-statusline.js CLI wrapper
- readSettings never silently defaults to {} on a parse failure, since settings.json isn't eridian-owned like state.json is
- /eridian:stats now runs the script instead of asking the model to hand-edit the JSON; allowed-tools simplifies to Bash(node:*) only

## Test plan
- [ ] `npm test` passes (settings.js unit tests, setup-statusline.js CLI tests)
- [ ] Manually run `/eridian:stats` on a machine with no statusLine configured, confirm the offer + apply flow works end to end
- [ ] Manually run `/eridian:stats` again, confirm it reports already-configured and doesn't touch the existing entry