### PR TITLE
feat: harden /eridian:compress with a validation gate

### DIFF
--- a/commands/compress.md
+++ b/commands/compress.md
@@ -1,29 +1,58 @@
 ---
 description: Compress CLAUDE.md or a memory file to cut input tokens (backup kept)
 argument-hint: "[path — defaults to ./CLAUDE.md]"
-allowed-tools: Bash(mkdir:*), Bash(cp:*), Bash(date:*), Bash(wc:*), Read, Write
+allowed-tools: Bash(mkdir:*), Bash(cp:*), Bash(date:*), Bash(node:*), Bash(diff:*), Bash(rm:*), Read, Write
 ---
 
 Target file: `$ARGUMENTS` (default `./CLAUDE.md`).
 
+0. Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-compress-path.js" <target>`.
+   If it exits non-zero, tell the user the printed reason and stop
+   completely — do not read the file, do not retry.
 1. Read the target file. If it does not exist, say so and stop.
 2. Rewrite it for pure density. This file is read by a model, not a human:
    - NO Rocky flavor. Plain, dense, factual prose and lists.
    - Preserve EVERY fact, constraint, rule, path, URL, and instruction.
    - Remove only redundancy, filler, hedging, and decorative prose.
    - Keep markdown structure (headings, lists) where it aids retrieval.
-3. Show the user: a summary of what was removed, plus before/after size
-   using the chars/4 token heuristic:
-   `before ~N tokens → after ~M tokens (−P%)` (run `wc -c` on the original;
-   count the rewrite's characters yourself).
-4. Ask for confirmation. Only proceed if the user confirms.
-5. Back up FIRST, then write:
+
+   Example of the technique:
+
+   Before:
+   ```
+   I strongly prefer that we always run the full test suite before
+   committing anything, just to be safe and make sure nothing broke.
+   Also, it would be great if you could try to keep commit messages
+   fairly short when possible.
+   ```
+
+   After:
+   ```
+   Run full test suite before every commit. Keep commit messages short.
+   ```
+
+3. Write the rewrite to `<target>.eridian-draft.tmp` (Write tool).
+4. Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/validate-compress.js" <target> <target>.eridian-draft.tmp`.
+   - Exit 0 (`PASS ...`): continue to step 5.
+   - Exit non-zero (`FAIL` + reasons): fix ONLY the flagged issues in the
+     draft — do not recompress from scratch — rewrite
+     `<target>.eridian-draft.tmp`, and re-run validation exactly once. If it
+     fails again: delete `<target>.eridian-draft.tmp`, report the reasons to
+     the user, and stop. The target file is never touched.
+5. Show the user: a summary of what was removed, plus the before/after size
+   from the `validate-compress.js` PASS line (it already reports
+   `N -> M chars (-P%)`).
+6. Ask for confirmation. Only proceed if the user confirms.
+7. Back up FIRST, verify the backup, then overwrite:
 
 ```bash
 mkdir -p ~/.claude/eridian/backups
 cp <target> ~/.claude/eridian/backups/"$(date -u +%Y%m%dT%H%M%SZ)"-<basename>
+diff ~/.claude/eridian/backups/<the-file-just-copied> <target>
 ```
 
-   Then overwrite the target with the compressed version. If the backup
-   command fails, do NOT write — report the failure instead.
-6. Confirm to the user, mention the backup path.
+   If the backup command fails, or `diff` reports any difference, do NOT
+   write — report the failure instead. Only after a clean `diff`, overwrite
+   `<target>` with the contents of `<target>.eridian-draft.tmp`, then
+   `rm <target>.eridian-draft.tmp`.
+8. Confirm to the user, mention the backup path.

--- a/scripts/check-compress-path.js
+++ b/scripts/check-compress-path.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const { isSensitivePath } = require('./lib/compress-guard');
+
+const target = process.argv[2];
+
+if (!target) {
+  console.log('refuse: no path given');
+  process.exit(1);
+}
+
+const result = isSensitivePath(target);
+
+if (result.ok) {
+  console.log('ok');
+  process.exit(0);
+} else {
+  console.log(result.reason);
+  process.exit(1);
+}

--- a/scripts/lib/compress-guard.js
+++ b/scripts/lib/compress-guard.js
@@ -1,0 +1,109 @@
+const SENSITIVE_EXTENSIONS = ['.env', '.pem'];
+const SENSITIVE_BASENAME_PATTERNS = [
+  /^id_(rsa|ed25519|ecdsa|dsa)$/i,
+  /^credentials/i,
+  /^secret/i,
+];
+const SENSITIVE_PATH_SEGMENTS = ['.ssh', '.aws', '.gnupg'];
+const SENSITIVE_NAME_TOKENS = ['apikey', 'token'];
+
+function isSensitivePath(filePath) {
+  const normalized = filePath.replace(/\\/g, '/');
+  const segments = normalized.split('/').filter(Boolean);
+  const basename = segments[segments.length - 1] || '';
+  const basenameLower = basename.toLowerCase();
+
+  for (const segment of SENSITIVE_PATH_SEGMENTS) {
+    if (segments.includes(segment)) {
+      return { ok: false, reason: `refuse: path contains sensitive directory (${segment})` };
+    }
+  }
+
+  for (const ext of SENSITIVE_EXTENSIONS) {
+    if (basenameLower.endsWith(ext)) {
+      return { ok: false, reason: `refuse: path matches credential pattern (${ext})` };
+    }
+  }
+
+  for (const pattern of SENSITIVE_BASENAME_PATTERNS) {
+    if (pattern.test(basename)) {
+      return {
+        ok: false,
+        reason: `refuse: filename matches credential pattern (${pattern.source})`,
+      };
+    }
+  }
+
+  for (const token of SENSITIVE_NAME_TOKENS) {
+    if (basenameLower.includes(token)) {
+      return { ok: false, reason: `refuse: filename contains sensitive token (${token})` };
+    }
+  }
+
+  return { ok: true };
+}
+
+function stripCodeBlocks(text) {
+  return text.replace(/```[\s\S]*?```/g, '');
+}
+
+function countHeadings(text) {
+  return (stripCodeBlocks(text).match(/^#{1,6}\s/gm) || []).length;
+}
+
+function extractCodeBlocks(text) {
+  return text.match(/```[\s\S]*?```/g) || [];
+}
+
+function extractUrls(text) {
+  const matches = text.match(/https?:\/\/\S+/g) || [];
+  return new Set(matches.map((url) => url.replace(/[),.;:'"]+$/, '')));
+}
+
+function validateDraft(originalText, draftText) {
+  const reasons = [];
+
+  if (draftText.trim().length === 0) {
+    return { ok: false, reasons: ['draft is empty'], summary: null };
+  }
+
+  if (draftText === originalText) {
+    reasons.push('draft is byte-identical to original');
+  }
+
+  const originalHeadings = countHeadings(originalText);
+  const draftHeadings = countHeadings(draftText);
+  if (originalHeadings !== draftHeadings) {
+    reasons.push(`heading count changed: original ${originalHeadings}, draft ${draftHeadings}`);
+  }
+
+  const originalBlocks = extractCodeBlocks(originalText);
+  const draftBlocks = extractCodeBlocks(draftText);
+  const draftBlockSet = new Set(draftBlocks);
+  originalBlocks.forEach((block, index) => {
+    if (!draftBlockSet.has(block)) {
+      reasons.push(
+        `code block dropped or altered: original block #${index + 1} not found unchanged in draft`
+      );
+    }
+  });
+
+  const originalUrls = extractUrls(originalText);
+  const draftUrls = extractUrls(draftText);
+  originalUrls.forEach((url) => {
+    if (!draftUrls.has(url)) {
+      reasons.push(`url dropped: ${url}`);
+    }
+  });
+
+  const summary = {
+    headings: [originalHeadings, draftHeadings],
+    codeBlocks: [originalBlocks.length, draftBlocks.length],
+    urls: [originalUrls.size, draftUrls.size],
+    chars: [originalText.length, draftText.length],
+  };
+
+  return { ok: reasons.length === 0, reasons, summary };
+}
+
+module.exports = { isSensitivePath, validateDraft };

--- a/scripts/lib/compress-guard.js
+++ b/scripts/lib/compress-guard.js
@@ -1,9 +1,5 @@
 const SENSITIVE_EXTENSIONS = ['.env', '.pem'];
-const SENSITIVE_BASENAME_PATTERNS = [
-  /^id_(rsa|ed25519|ecdsa|dsa)$/i,
-  /^credentials/i,
-  /^secret/i,
-];
+const SENSITIVE_BASENAME_PATTERNS = [/^id_(rsa|ed25519|ecdsa|dsa)$/i, /^credentials/i, /^secret/i];
 const SENSITIVE_PATH_SEGMENTS = ['.ssh', '.aws', '.gnupg'];
 const SENSITIVE_NAME_TOKENS = ['apikey', 'token'];
 

--- a/scripts/validate-compress.js
+++ b/scripts/validate-compress.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const { validateDraft } = require('./lib/compress-guard');
+
+const [originalPath, draftPath] = process.argv.slice(2);
+
+if (!originalPath || !draftPath) {
+  console.log('FAIL');
+  console.log('usage: validate-compress.js <original-path> <draft-path>');
+  process.exit(1);
+}
+
+let originalText;
+let draftText;
+
+try {
+  originalText = fs.readFileSync(originalPath, 'utf8');
+} catch {
+  console.log('FAIL');
+  console.log(`cannot read original: ${originalPath}`);
+  process.exit(1);
+}
+
+try {
+  draftText = fs.readFileSync(draftPath, 'utf8');
+} catch {
+  console.log('FAIL');
+  console.log(`cannot read draft: ${draftPath}`);
+  process.exit(1);
+}
+
+const result = validateDraft(originalText, draftText);
+
+if (result.ok) {
+  const { headings, codeBlocks, urls, chars } = result.summary;
+  const pct = chars[0] > 0 ? (((chars[0] - chars[1]) / chars[0]) * 100).toFixed(1) : '0.0';
+  console.log(
+    `PASS headings ${headings[1]}/${headings[0]}, ` +
+      `code-blocks ${codeBlocks[1]}/${codeBlocks[0]}, ` +
+      `urls ${urls[1]}/${urls[0]}, ` +
+      `${chars[0]} -> ${chars[1]} chars (-${pct}%)`
+  );
+  process.exit(0);
+} else {
+  console.log('FAIL');
+  result.reasons.forEach((reason) => console.log(reason));
+  process.exit(1);
+}

--- a/test/check-compress-path.test.js
+++ b/test/check-compress-path.test.js
@@ -1,0 +1,22 @@
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const test = require('node:test');
+const assert = require('node:assert');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'check-compress-path.js');
+
+test('check-compress-path.js exits 0 and prints ok for a safe path', () => {
+  const out = execFileSync('node', [SCRIPT, './CLAUDE.md'], { encoding: 'utf8' });
+  assert.match(out, /^ok/);
+});
+
+test('check-compress-path.js exits 1 and prints a refusal for a .env path', () => {
+  assert.throws(
+    () => execFileSync('node', [SCRIPT, '/some/project/.env'], { encoding: 'utf8' }),
+    (err) => {
+      assert.strictEqual(err.status, 1);
+      assert.match(err.stdout.toString(), /^refuse:/);
+      return true;
+    }
+  );
+});

--- a/test/compress-guard.test.js
+++ b/test/compress-guard.test.js
@@ -1,0 +1,107 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { isSensitivePath, validateDraft } = require('../scripts/lib/compress-guard');
+
+test('isSensitivePath refuses .env files', () => {
+  assert.strictEqual(isSensitivePath('/Users/joao/project/.env').ok, false);
+});
+
+test('isSensitivePath refuses .pem files', () => {
+  assert.strictEqual(isSensitivePath('keys/server.pem').ok, false);
+});
+
+test('isSensitivePath refuses id_rsa-style key filenames', () => {
+  assert.strictEqual(isSensitivePath('/home/user/.ssh/id_rsa').ok, false);
+  assert.strictEqual(isSensitivePath('id_ed25519').ok, false);
+});
+
+test('isSensitivePath refuses credentials/secret-prefixed filenames', () => {
+  assert.strictEqual(isSensitivePath('config/credentials.json').ok, false);
+  assert.strictEqual(isSensitivePath('secrets.yaml').ok, false);
+});
+
+test('isSensitivePath refuses paths inside .ssh, .aws, .gnupg', () => {
+  assert.strictEqual(isSensitivePath('/home/user/.ssh/config').ok, false);
+  assert.strictEqual(isSensitivePath('/home/user/.aws/credentials-backup').ok, false);
+  assert.strictEqual(isSensitivePath('/home/user/.gnupg/pubring.kbx').ok, false);
+});
+
+test('isSensitivePath refuses filenames containing apikey or token', () => {
+  assert.strictEqual(isSensitivePath('my-apikey.txt').ok, false);
+  assert.strictEqual(isSensitivePath('slack-token.md').ok, false);
+});
+
+test('isSensitivePath allows a normal CLAUDE.md', () => {
+  assert.strictEqual(isSensitivePath('./CLAUDE.md').ok, true);
+  assert.strictEqual(isSensitivePath('docs/notes.md').ok, true);
+});
+
+test('validateDraft passes when structure is preserved', () => {
+  const original =
+    '# Title\n\nSome verbose text here explaining things at length.\n\n' +
+    '## Section\n\n```bash\nnpm test\n```\n\nSee https://example.com/docs for more.\n';
+  const draft =
+    '# Title\n\nDense text.\n\n' +
+    '## Section\n\n```bash\nnpm test\n```\n\nSee https://example.com/docs.\n';
+  const result = validateDraft(original, draft);
+  assert.strictEqual(result.ok, true);
+  assert.deepStrictEqual(result.reasons, []);
+  assert.deepStrictEqual(result.summary.headings, [2, 2]);
+  assert.deepStrictEqual(result.summary.codeBlocks, [1, 1]);
+  assert.deepStrictEqual(result.summary.urls, [1, 1]);
+});
+
+test('validateDraft fails on an empty draft', () => {
+  const result = validateDraft('# Title\n\ntext\n', '   \n');
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.reasons.includes('draft is empty'));
+  assert.strictEqual(result.summary, null);
+});
+
+test('validateDraft fails when draft is byte-identical to original', () => {
+  const text = '# Title\n\nSame text.\n';
+  const result = validateDraft(text, text);
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.reasons.includes('draft is byte-identical to original'));
+});
+
+test('validateDraft fails when heading count changes', () => {
+  const original = '# Title\n\n## Section A\n\n## Section B\n\ntext\n';
+  const draft = '# Title\n\n## Section A\n\ntext\n';
+  const result = validateDraft(original, draft);
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.reasons.some((r) => r === 'heading count changed: original 3, draft 2'));
+});
+
+test('validateDraft ignores # lines inside code blocks when counting headings', () => {
+  const text = '# Title\n\nProse.\n\n```bash\n# not a heading\nnpm test\n```\n';
+  const result = validateDraft(text, text);
+  assert.deepStrictEqual(result.summary.headings, [1, 1]);
+});
+
+test('validateDraft fails when a code block is altered', () => {
+  const original = '# Title\n\n```bash\nnpm test\n```\n';
+  const draft = '# Title\n\n```bash\nnpm run test\n```\n';
+  const result = validateDraft(original, draft);
+  assert.strictEqual(result.ok, false);
+  assert.ok(
+    result.reasons.includes(
+      'code block dropped or altered: original block #1 not found unchanged in draft'
+    )
+  );
+});
+
+test('validateDraft fails when a url is dropped', () => {
+  const original = '# Title\n\nSee https://example.com/docs and https://example.com/api.\n';
+  const draft = '# Title\n\nSee https://example.com/docs.\n';
+  const result = validateDraft(original, draft);
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.reasons.includes('url dropped: https://example.com/api'));
+});
+
+test('validateDraft does not flag urls added in the draft', () => {
+  const original = '# Title\n\ntext\n';
+  const draft = '# Title\n\ntext, see https://example.com/new\n';
+  const result = validateDraft(original, draft);
+  assert.strictEqual(result.ok, true);
+});

--- a/test/validate-compress.test.js
+++ b/test/validate-compress.test.js
@@ -1,0 +1,51 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const test = require('node:test');
+const assert = require('node:assert');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'validate-compress.js');
+
+function writeTemp(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-validate-'));
+  const file = path.join(dir, 'file.md');
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+test('validate-compress.js exits 0 and prints PASS for a valid compression', () => {
+  const original = writeTemp('# Title\n\nVerbose text about things.\n\n```bash\nnpm test\n```\n');
+  const draft = writeTemp('# Title\n\nDense text.\n\n```bash\nnpm test\n```\n');
+  const out = execFileSync('node', [SCRIPT, original, draft], { encoding: 'utf8' });
+  assert.match(out, /^PASS/);
+  assert.match(out, /headings 1\/1/);
+  assert.match(out, /code-blocks 1\/1/);
+});
+
+test('validate-compress.js exits 1 and prints FAIL reasons when a code block changes', () => {
+  const original = writeTemp('# Title\n\n```bash\nnpm test\n```\n');
+  const draft = writeTemp('# Title\n\n```bash\nnpm run test\n```\n');
+  assert.throws(
+    () => execFileSync('node', [SCRIPT, original, draft], { encoding: 'utf8' }),
+    (err) => {
+      assert.strictEqual(err.status, 1);
+      assert.match(err.stdout.toString(), /^FAIL/);
+      assert.match(err.stdout.toString(), /code block dropped or altered/);
+      return true;
+    }
+  );
+});
+
+test('validate-compress.js exits 1 when the draft file is empty', () => {
+  const original = writeTemp('# Title\n\ntext\n');
+  const draft = writeTemp('   \n');
+  assert.throws(
+    () => execFileSync('node', [SCRIPT, original, draft], { encoding: 'utf8' }),
+    (err) => {
+      assert.strictEqual(err.status, 1);
+      assert.match(err.stdout.toString(), /draft is empty/);
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- Refuse to compress files matching a credential/secret path pattern, before ever reading them
- Add a deterministic validate-compress.js gate checking heading count, code-block integrity, and URL preservation survive the model's rewrite, with one bounded retry on failure
- Verify the backup with `diff` before overwriting the real target
- Add an inline before/after example of the compression technique

## Test plan
- [ ] `npm test` passes (compress-guard, check-compress-path, validate-compress unit/CLI tests)
- [ ] Manually run `/eridian:compress` against a real CLAUDE.md and confirm the PASS summary, backup, and overwrite all work end to end
- [ ] Manually run `/eridian:compress` against a path like `.env` and confirm it refuses before reading