### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "eridian",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Talk terse like Rocky from Project Hail Mary. Save output tokens. Amaze.",
   "author": { "name": "João Oliveira" }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eridian-plugin",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Rocky-speak token compression plugin for Claude Code",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bumps `.claude-plugin/plugin.json` and `package.json` from 0.1.0 → 0.2.0
- Unblocks `/plugin update eridian@eridian` for existing installs: `plugin update` gates on the `version` string, not commit content, so the 5 commits merged since the rename (#2, #3, #4 + 2 more) were invisible to anyone who installed before they landed
- No tag has ever been cut for this repo; after merge, run `claude plugin tag --push` to create `eridian--v0.2.0` and make it pullable

## Test plan
- [x] `claude plugin validate .` passes
- [x] `claude plugin tag --dry-run` resolves cleanly to `eridian--v0.2.0` at HEAD
- [ ] After merge + tag push: confirm `/plugin marketplace update && /plugin update eridian@eridian` picks up 0.2.0 on a clean install pinned to 0.1.0