### PR TITLE
fix: anchor release-please to ebcbec3 via bootstrap-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "ebcbec33a79f2ae17a1072b4a3246a15507dc65d",
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- Follow-up to #6. The first live run of the release-please workflow logged `No latest release found for path: ., component: eridian-plugin, but a previous version (0.2.0) was specified in the manifest` and was about to bump straight to `1.0.0` — it only recognizes a GitHub *Release* object as "the last release," not the `v0.2.0` git tag pushed alongside #6.
- Adds a top-level `bootstrap-sha` pointing at `ebcbec3` (the last manual bump) to `release-please-config.json`, so it computes the next version as an increment from the manifest's `0.2.0` using commits after that SHA — no GitHub Release object required.

## Test plan
- [x] `npm test && npm run lint && npm run format:check` pass locally
- [x] CI green on this PR
- [ ] After merge: confirm the release-please workflow run succeeds and opens a Release PR with a sane version bump (not 1.0.0)