### PR TITLE
fix: reinforce eridian persona across long sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [0.2.1](https://github.com/jpboliv/eridian/compare/eridian-plugin-v0.2.0...eridian-plugin-v0.2.1) (2026-07-03)
 
-
 ### Bug Fixes
 
-* anchor release-please to ebcbec3 via bootstrap-sha ([#7](https://github.com/jpboliv/eridian/issues/7)) ([eedd684](https://github.com/jpboliv/eridian/commit/eedd68406a2baf171479c556618ae9adbe4d2c9f))
+- anchor release-please to ebcbec3 via bootstrap-sha ([#7](https://github.com/jpboliv/eridian/issues/7)) ([eedd684](https://github.com/jpboliv/eridian/commit/eedd68406a2baf171479c556618ae9adbe4d2c9f))

--- a/scripts/buddy-hook.js
+++ b/scripts/buddy-hook.js
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+// Long sessions dilute the once-at-SessionStart persona instruction, so
+// re-assert it periodically via UserPromptSubmit (whose plain stdout Claude
+// Code shows to Claude, unlike most other hook events).
+const REINJECT_EVERY_PROMPTS = 20;
+
 function main(raw) {
   const { update } = require('./lib/state');
   const { classifyPrompt } = require('./lib/classify');
@@ -13,11 +18,28 @@ function main(raw) {
   const now = new Date().toISOString();
 
   if (kind === 'prompt') {
+    let reinjectLevel = null;
     update((s) => {
       s.buddy.lastPromptAt = now;
       s.buddy.promptClass = classifyPrompt(input.prompt);
+      if (s.current && s.current !== 'off') {
+        s.promptsSinceReinject = (s.promptsSinceReinject || 0) + 1;
+        if (s.promptsSinceReinject >= REINJECT_EVERY_PROMPTS) {
+          s.promptsSinceReinject = 0;
+          reinjectLevel = s.current;
+        }
+      }
       return s;
     });
+    if (reinjectLevel) {
+      const { loadInjectionBlock } = require('./lib/persona');
+      const block = loadInjectionBlock(reinjectLevel);
+      if (block) {
+        process.stdout.write(
+          `Eridian mode "${reinjectLevel}" reminder (long session — re-asserting style):\n\n${block}`
+        );
+      }
+    }
   } else if (kind === 'post-tool') {
     const resp = input.tool_response;
     const isError =

--- a/scripts/lib/state.js
+++ b/scripts/lib/state.js
@@ -29,6 +29,7 @@ const DEFAULT_STATE = {
   events: [],
   cache: null,
   buddy: {},
+  promptsSinceReinject: 0,
 };
 
 function readState() {

--- a/scripts/mode.js
+++ b/scripts/mode.js
@@ -18,6 +18,7 @@ if (!arg) {
 update((s) => {
   s.current = target;
   s.events.push({ ts: new Date().toISOString(), level: target });
+  s.promptsSinceReinject = 0;
   return s;
 });
 

--- a/scripts/session-start.js
+++ b/scripts/session-start.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 try {
-  const { readState } = require('./lib/state');
+  const { readState, update } = require('./lib/state');
   const { loadInjectionBlock } = require('./lib/persona');
 
   const state = readState();
@@ -15,6 +15,12 @@ try {
           },
         })
       );
+      // Every SessionStart fire (startup/resume/clear/compact) re-asserts the
+      // persona, so the UserPromptSubmit reinject countdown can start fresh.
+      update((s) => {
+        s.promptsSinceReinject = 0;
+        return s;
+      });
     }
   }
 } catch {

--- a/test/buddy-hook.test.js
+++ b/test/buddy-hook.test.js
@@ -20,6 +20,11 @@ function readStateFile(dir) {
   return JSON.parse(fs.readFileSync(path.join(dir, 'state.json'), 'utf8'));
 }
 
+function writeStateFile(dir, state) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'state.json'), JSON.stringify(state));
+}
+
 test('prompt event records timestamp and class', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-bh-'));
   const out = run('prompt', { prompt: 'fix the crash please' }, dir);
@@ -41,6 +46,46 @@ test('post-tool records lastErrorAt on error-looking response', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-bh-'));
   run('post-tool', { tool_name: 'Bash', tool_response: { is_error: true } }, dir);
   assert.ok(readStateFile(dir).buddy.lastErrorAt);
+});
+
+test('prompt event reinjects persona block once enough prompts accumulate', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-bh-'));
+  writeStateFile(dir, {
+    current: 'full',
+    events: [],
+    cache: null,
+    buddy: {},
+    promptsSinceReinject: 999,
+  });
+  const out = run('prompt', { prompt: 'fix the crash please' }, dir);
+  assert.match(out, /ROCKY MODE \(full\)/);
+  assert.strictEqual(readStateFile(dir).promptsSinceReinject, 0);
+});
+
+test('prompt event stays silent before the reinject threshold', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-bh-'));
+  writeStateFile(dir, {
+    current: 'full',
+    events: [],
+    cache: null,
+    buddy: {},
+    promptsSinceReinject: 1,
+  });
+  const out = run('prompt', { prompt: 'fix the crash please' }, dir);
+  assert.strictEqual(out, '');
+});
+
+test('prompt event never reinjects when eridian mode is off', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-bh-'));
+  writeStateFile(dir, {
+    current: 'off',
+    events: [],
+    cache: null,
+    buddy: {},
+    promptsSinceReinject: 999,
+  });
+  const out = run('prompt', { prompt: 'fix the crash please' }, dir);
+  assert.strictEqual(out, '');
 });
 
 test('garbage stdin exits 0 silently', () => {

--- a/test/mode.test.js
+++ b/test/mode.test.js
@@ -46,3 +46,21 @@ test('unknown level prints usage, state unchanged', () => {
   assert.match(out, /unknown level/);
   assert.ok(!fs.existsSync(path.join(dir, 'state.json')));
 });
+
+test('activating a level resets the reinject counter', () => {
+  const dir = freshDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'state.json'),
+    JSON.stringify({
+      current: 'off',
+      events: [],
+      cache: null,
+      buddy: {},
+      promptsSinceReinject: 19,
+    })
+  );
+  run(['full'], dir);
+  const state = JSON.parse(fs.readFileSync(path.join(dir, 'state.json'), 'utf8'));
+  assert.strictEqual(state.promptsSinceReinject, 0);
+});

--- a/test/session-start.test.js
+++ b/test/session-start.test.js
@@ -35,3 +35,20 @@ test('prints nothing when off', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-ss-'));
   assert.strictEqual(run(dir), '');
 });
+
+test('resets the reinject counter so a fresh session/compact starts clean', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-ss-'));
+  fs.writeFileSync(
+    path.join(dir, 'state.json'),
+    JSON.stringify({
+      current: 'full',
+      events: [],
+      cache: null,
+      buddy: {},
+      promptsSinceReinject: 15,
+    })
+  );
+  run(dir);
+  const state = JSON.parse(fs.readFileSync(path.join(dir, 'state.json'), 'utf8'));
+  assert.strictEqual(state.promptsSinceReinject, 0);
+});

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -15,6 +15,7 @@ test('readState returns default when file missing', () => {
     events: [],
     cache: null,
     buddy: {},
+    promptsSinceReinject: 0,
   });
 });
 


### PR DESCRIPTION
## Summary
- Rocky/eridian mode drifted away silently in long sessions — the persona instruction was injected exactly once at `SessionStart` and nothing ever refreshed it.
- `SessionStart` already re-fires on `compact` (docs confirm an omitted matcher covers `startup`/`resume`/`clear`/`compact`), but a single injection still loses influence over a long, dense conversation between those boundary events.
- `buddy-hook.js`'s `UserPromptSubmit` handler (fires every turn already, for buddy-mood tracking) now also counts prompts and re-prints the persona block every 20 prompts while a mode is active — its plain stdout is one of the few hook outputs Claude Code actually shows to Claude.
- `session-start.js` and `mode.js` reset that countdown whenever a real refresh already happened (session start/resume/clear/compact, or a `/eridian:mode` change), so refreshes don't stack redundantly.

## Test plan
- [x] `npm test` — 94/94 passing (new tests added: reinject-after-threshold, silent-before-threshold, silent-when-off, counter resets on SessionStart and mode activation)
- [x] `npm run lint` — clean
- [x] `npx prettier --check` on all changed files — clean