### PR TITLE
feat: session-based savings with auto-refreshing statusline

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ idle. Run `/eridian:stats` once to set the statusline up:
 ▘ ▘ ▘▘
 ```
 
+The savings figure is the **current session's** estimate, computed live
+from the session transcript on every statusline refresh. Rocky dances when
+the session crosses a savings milestone (5k/10k/25k/50k/100k). Lifetime
+totals live in `/eridian:stats`.
+
+Rocky animates whenever Claude Code refreshes the statusline (i.e. while
+the conversation is active); when you idle, the last frame stays put until
+the next refresh — that cadence is the host's, not Rocky's.
+
+Using your own statusline script instead of the generated one? Forward the
+JSON that Claude Code pipes on stdin, or the savings segment is omitted:
+
+```sh
+rocky=$(printf '%s' "$input" | node "<plugin-root>/scripts/statusline.js" 2>/dev/null)
+```
+
 ## Savings
 
 Measured on 10 real coding prompts via `claude -p`, one run per prompt/mode

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,7 @@ module.exports = [
         console: 'readonly',
         Buffer: 'readonly',
         structuredClone: 'readonly',
+        setTimeout: 'readonly',
       },
     },
   },

--- a/scripts/lib/session-savings.js
+++ b/scripts/lib/session-savings.js
@@ -1,0 +1,162 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { STATE_DIR } = require('./state');
+const { buildWindows, attribute, estimateSaved, MILESTONES } = require('./stats-lib');
+
+const SESSIONS_DIR = path.join(STATE_DIR, 'sessions');
+const PRUNE_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+
+function emptyCache(transcriptPath) {
+  return {
+    transcriptPath,
+    offset: 0,
+    sessionStartMs: null,
+    tokensByLevel: {},
+    milestonesHit: [],
+    savedTokens: 0,
+  };
+}
+
+function cacheFile(sessionId) {
+  return path.join(SESSIONS_DIR, `${sessionId}.json`);
+}
+
+function readCache(sessionId, transcriptPath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cacheFile(sessionId), 'utf8'));
+    if (parsed && typeof parsed === 'object' && parsed.transcriptPath === transcriptPath) {
+      return { ...emptyCache(transcriptPath), ...parsed };
+    }
+  } catch {
+    // missing or corrupt — start fresh
+  }
+  return emptyCache(transcriptPath);
+}
+
+function prune(nowMs) {
+  try {
+    for (const f of fs.readdirSync(SESSIONS_DIR)) {
+      const p = path.join(SESSIONS_DIR, f);
+      if (nowMs - fs.statSync(p).mtimeMs > PRUNE_AFTER_MS) fs.unlinkSync(p);
+    }
+  } catch {
+    // best effort
+  }
+}
+
+function writeCache(sessionId, cache, nowMs) {
+  fs.mkdirSync(SESSIONS_DIR, { recursive: true });
+  const file = cacheFile(sessionId);
+  const tmp = `${file}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(cache));
+  fs.renameSync(tmp, file);
+  prune(nowMs);
+}
+
+// Reads complete lines past `offset`; a partial trailing line (no newline
+// yet) stays unconsumed so it re-reads whole next time. Returns null when
+// the file shrank (truncated/replaced) so the caller can reset.
+function scanNewLines(transcriptPath, offset) {
+  const size = fs.statSync(transcriptPath).size;
+  if (size < offset) return null;
+  if (size === offset) return { messages: [], minTsMs: null, newOffset: offset };
+
+  const buf = Buffer.alloc(size - offset);
+  const fd = fs.openSync(transcriptPath, 'r');
+  try {
+    fs.readSync(fd, buf, 0, buf.length, offset);
+  } finally {
+    fs.closeSync(fd);
+  }
+  const text = buf.toString('utf8');
+  const lastNl = text.lastIndexOf('\n');
+  if (lastNl === -1) return { messages: [], minTsMs: null, newOffset: offset };
+  const complete = text.slice(0, lastNl + 1);
+
+  const messages = [];
+  let minTsMs = null;
+  for (const line of complete.split('\n')) {
+    try {
+      const obj = JSON.parse(line);
+      const tsMs = Date.parse(obj?.timestamp);
+      if (Number.isFinite(tsMs) && (minTsMs === null || tsMs < minTsMs)) minTsMs = tsMs;
+      const tokens = obj?.message?.usage?.output_tokens;
+      if (obj.type === 'assistant' && Number.isFinite(tsMs) && tokens > 0) {
+        messages.push({ tsMs, outputTokens: tokens });
+      }
+    } catch {
+      /* skip malformed lines */
+    }
+  }
+  return { messages, minTsMs, newOffset: offset + Buffer.byteLength(complete, 'utf8') };
+}
+
+function sessionSavings({ sessionId, transcriptPath }, state, factors, nowMs) {
+  if (!sessionId || typeof sessionId !== 'string' || !/^[\w.-]+$/.test(sessionId)) return null;
+  if (!transcriptPath) return null;
+
+  let cache = readCache(sessionId, transcriptPath);
+  let scan;
+  try {
+    scan = scanNewLines(transcriptPath, cache.offset);
+    if (scan === null) {
+      cache = emptyCache(transcriptPath);
+      scan = scanNewLines(transcriptPath, 0);
+    }
+  } catch {
+    return null; // transcript missing/unreadable
+  }
+  if (scan === null) return null;
+
+  if (
+    scan.minTsMs !== null &&
+    (cache.sessionStartMs === null || scan.minTsMs < cache.sessionStartMs)
+  ) {
+    cache.sessionStartMs = scan.minTsMs;
+  }
+
+  if (scan.messages.length) {
+    const windows = buildWindows(state.events || [], nowMs);
+    const withStart = scan.messages.map((m) => ({
+      ...m,
+      sessionStartMs: cache.sessionStartMs ?? m.tsMs,
+    }));
+    for (const [level, t] of Object.entries(attribute(withStart, windows))) {
+      cache.tokensByLevel[level] = (cache.tokensByLevel[level] || 0) + t.tokens;
+    }
+  }
+
+  const byLevel = Object.fromEntries(
+    Object.entries(cache.tokensByLevel).map(([level, tokens]) => [level, { tokens }])
+  );
+  const savedTokens = estimateSaved(byLevel, factors);
+  const crossed = MILESTONES.filter((m) => savedTokens >= m && !cache.milestonesHit.includes(m));
+
+  cache.savedTokens = savedTokens;
+  cache.milestonesHit = [...cache.milestonesHit, ...crossed];
+  cache.offset = scan.newOffset;
+  try {
+    writeCache(sessionId, cache, nowMs);
+  } catch {
+    // cache write is best-effort; the computed values still stand
+  }
+  return { savedTokens, crossed };
+}
+
+function latestSessionSaved() {
+  try {
+    let best = null;
+    for (const f of fs.readdirSync(SESSIONS_DIR).filter((f) => f.endsWith('.json'))) {
+      const p = path.join(SESSIONS_DIR, f);
+      const mtimeMs = fs.statSync(p).mtimeMs;
+      if (!best || mtimeMs > best.mtimeMs) best = { p, mtimeMs };
+    }
+    if (!best) return null;
+    const saved = JSON.parse(fs.readFileSync(best.p, 'utf8')).savedTokens;
+    return Number.isFinite(saved) ? saved : null;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { sessionSavings, latestSessionSaved, SESSIONS_DIR };

--- a/scripts/lib/state.js
+++ b/scripts/lib/state.js
@@ -27,7 +27,6 @@ if (!process.env.ERIDIAN_STATE_DIR) {
 const DEFAULT_STATE = {
   current: 'off',
   events: [],
-  cache: null,
   buddy: {},
   promptsSinceReinject: 0,
 };

--- a/scripts/lib/stats-lib.js
+++ b/scripts/lib/stats-lib.js
@@ -1,4 +1,4 @@
-const MILESTONES = [10_000, 50_000, 100_000, 500_000, 1_000_000];
+const MILESTONES = [5_000, 10_000, 25_000, 50_000, 100_000];
 
 function buildWindows(events, nowMs) {
   const sorted = [...events]

--- a/scripts/stats.js
+++ b/scripts/stats.js
@@ -2,9 +2,11 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { readState, update } = require('./lib/state');
-const { buildWindows, attribute, estimateSaved, crossedMilestones } = require('./lib/stats-lib');
+const { readState } = require('./lib/state');
+const { buildWindows, attribute, estimateSaved } = require('./lib/stats-lib');
 const { collectMessages } = require('./lib/collect-messages');
+const { latestSessionSaved } = require('./lib/session-savings');
+const { formatTokens } = require('./statusline');
 
 const PROJECTS_DIR =
   process.env.CLAUDE_PROJECTS_DIR || path.join(os.homedir(), '.claude', 'projects');
@@ -17,20 +19,17 @@ const windows = buildWindows(state.events, Date.now());
 const { messages, sessions } = collectMessages(PROJECTS_DIR);
 const totals = attribute(messages, windows);
 const saved = estimateSaved(totals, FACTORS);
-const oldSaved = state.cache?.savedTokens || 0;
-const milestones = crossedMilestones(oldSaved, saved);
-
-update((s) => {
-  s.cache = {
-    savedTokens: saved,
-    messages: Object.values(totals).reduce((n, t) => n + t.messages, 0),
-    updatedAt: new Date().toISOString(),
-  };
-  if (milestones.length) s.buddy.milestoneAt = new Date().toISOString();
-  return s;
-});
 
 console.log('♫ eridian stats (all numbers estimated)\n');
+
+const sessionSaved = latestSessionSaved();
+if (sessionSaved === null) {
+  console.log('this session: (no data)\n');
+} else {
+  console.log(`this session: ~${formatTokens(sessionSaved)} saved (${state.current})\n`);
+}
+
+console.log('lifetime (all sessions):');
 console.log('level  messages  output tokens  est. saved');
 for (const [level, t] of Object.entries(totals)) {
   const levelSaved = Math.round(t.tokens / (1 - FACTORS[level]) - t.tokens);
@@ -41,4 +40,3 @@ for (const [level, t] of Object.entries(totals)) {
 if (!Object.keys(totals).length) console.log('(no eridian-mode messages found yet)');
 console.log(`\nlifetime est. saved: ~${saved} tokens`);
 console.log(`sessions scanned: ${sessions}`);
-if (milestones.length) console.log(`milestone crossed: ${milestones.join(', ')} — good good good!`);

--- a/scripts/statusline.js
+++ b/scripts/statusline.js
@@ -7,18 +7,18 @@ function formatTokens(n) {
   return String(n);
 }
 
-function infoSegments(state) {
+function infoSegments(state, savedTokens) {
   const parts = [`∙ ${state.current}`];
-  if (state.cache && typeof state.cache.savedTokens === 'number') {
-    parts.push(`∙ ~${formatTokens(state.cache.savedTokens)} saved`);
+  if (typeof savedTokens === 'number') {
+    parts.push(`∙ ~${formatTokens(savedTokens)} saved`);
   }
   return parts;
 }
 
-function renderLines(state, nowMs) {
+function renderLines(state, nowMs, savedTokens) {
   if (!state.current || state.current === 'off') return [];
 
-  const info = infoSegments(state).join('  ');
+  const info = infoSegments(state, savedTokens).join('  ');
   const { rows, quip } = renderBuddy(state.buddy || {}, nowMs);
 
   // quip rides the arms+dome (top) row like a speech bubble; info rides the
@@ -34,12 +34,50 @@ function renderLines(state, nowMs) {
 module.exports = { renderLines, formatTokens };
 
 if (require.main === module) {
-  // Claude Code pipes session JSON on stdin; we render from our own state.
-  try {
-    const { readState } = require('./lib/state');
-    process.stdout.write(renderLines(readState(), Date.now()).join('\n'));
-  } catch {
-    // statusline must never crash the host renderer
-  }
-  process.exit(0);
+  // Claude Code pipes session JSON on stdin; the savings segment comes from
+  // the current session's transcript, everything else from our own state.
+  const render = (raw) => {
+    try {
+      const { readState, update } = require('./lib/state');
+      const state = readState();
+      const nowMs = Date.now();
+      let savedTokens = null;
+      try {
+        const input = JSON.parse(raw);
+        const fs = require('node:fs');
+        const path = require('node:path');
+        const { sessionSavings } = require('./lib/session-savings');
+        const factors = JSON.parse(
+          fs.readFileSync(path.join(__dirname, '..', 'eval', 'factors.json'), 'utf8')
+        );
+        const result = sessionSavings(
+          { sessionId: input.session_id, transcriptPath: input.transcript_path },
+          state,
+          factors,
+          nowMs
+        );
+        if (result) {
+          savedTokens = result.savedTokens;
+          if (result.crossed.length) {
+            update((s) => {
+              s.buddy.milestoneAt = new Date(nowMs).toISOString();
+              return s;
+            });
+          }
+        }
+      } catch {
+        // no/garbage stdin or unreadable transcript — render without savings
+      }
+      process.stdout.write(renderLines(state, nowMs, savedTokens).join('\n'));
+    } catch {
+      // statusline must never crash the host renderer
+    }
+    process.exit(0);
+  };
+
+  let raw = '';
+  process.stdin.on('data', (c) => (raw += c));
+  process.stdin.on('end', () => render(raw));
+  // never hang if stdin stays open (e.g. run by hand from a TTY)
+  setTimeout(() => render(raw), 250);
 }

--- a/test/session-savings.test.js
+++ b/test/session-savings.test.js
@@ -1,0 +1,176 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+process.env.ERIDIAN_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-ss-'));
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  sessionSavings,
+  latestSessionSaved,
+  SESSIONS_DIR,
+} = require('../scripts/lib/session-savings');
+
+const T0 = Date.parse('2026-07-08T10:00:00Z');
+const mins = (n) => T0 + n * 60_000;
+const iso = (ms) => new Date(ms).toISOString();
+const FACTORS = { full: 0.5, ultra: 0.9 };
+
+// state with full mode active since T0 (session will start inside the window)
+const stateOn = { current: 'full', events: [{ ts: iso(mins(0)), level: 'full' }], buddy: {} };
+
+let seq = 0;
+function tmpTranscript(lines) {
+  const p = path.join(process.env.ERIDIAN_STATE_DIR, `transcript-${seq++}.jsonl`);
+  fs.writeFileSync(p, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+  return p;
+}
+
+function assistant(atMin, tokens) {
+  return {
+    type: 'assistant',
+    timestamp: iso(mins(atMin)),
+    message: { usage: { output_tokens: tokens } },
+  };
+}
+
+function cachePath(id) {
+  return path.join(SESSIONS_DIR, `${id}.json`);
+}
+
+test('computes savings for messages inside an active window', () => {
+  const tp = tmpTranscript([assistant(5, 100)]);
+  const r = sessionSavings(
+    { sessionId: 's-basic', transcriptPath: tp },
+    stateOn,
+    FACTORS,
+    mins(10)
+  );
+  // 100/(1-0.5) - 100 = 100
+  assert.strictEqual(r.savedTokens, 100);
+});
+
+test('incremental: second call reads only appended bytes and accumulates', () => {
+  const tp = tmpTranscript([assistant(5, 100)]);
+  const id = 's-incr';
+  sessionSavings({ sessionId: id, transcriptPath: tp }, stateOn, FACTORS, mins(10));
+  const offsetAfterFirst = JSON.parse(fs.readFileSync(cachePath(id), 'utf8')).offset;
+  assert.strictEqual(offsetAfterFirst, fs.statSync(tp).size);
+
+  fs.appendFileSync(tp, JSON.stringify(assistant(6, 100)) + '\n');
+  const r = sessionSavings({ sessionId: id, transcriptPath: tp }, stateOn, FACTORS, mins(10));
+  assert.strictEqual(r.savedTokens, 200);
+  assert.strictEqual(
+    JSON.parse(fs.readFileSync(cachePath(id), 'utf8')).offset,
+    fs.statSync(tp).size
+  );
+});
+
+test('partial trailing line is not consumed until its newline arrives', () => {
+  const tp = tmpTranscript([assistant(5, 100)]);
+  const id = 's-partial';
+  const half = JSON.stringify(assistant(6, 100));
+  fs.appendFileSync(tp, half.slice(0, 20)); // no newline, malformed tail
+  const r1 = sessionSavings({ sessionId: id, transcriptPath: tp }, stateOn, FACTORS, mins(10));
+  assert.strictEqual(r1.savedTokens, 100);
+
+  fs.appendFileSync(tp, half.slice(20) + '\n');
+  const r2 = sessionSavings({ sessionId: id, transcriptPath: tp }, stateOn, FACTORS, mins(10));
+  assert.strictEqual(r2.savedTokens, 200);
+});
+
+test('messages outside any mode window do not count', () => {
+  // window opens at min 10; message at min 5 is before it, session start too
+  const stateLate = { current: 'full', events: [{ ts: iso(mins(10)), level: 'full' }], buddy: {} };
+  const tp = tmpTranscript([assistant(5, 100)]);
+  const r = sessionSavings(
+    { sessionId: 's-window', transcriptPath: tp },
+    stateLate,
+    FACTORS,
+    mins(20)
+  );
+  assert.strictEqual(r.savedTokens, 0);
+});
+
+test('session started before mode-on: nothing counts (persona never injected)', () => {
+  const stateLate = { current: 'full', events: [{ ts: iso(mins(10)), level: 'full' }], buddy: {} };
+  // session starts at min 5 (first line), message at min 15 inside the window
+  const tp = tmpTranscript([assistant(5, 10), assistant(15, 100)]);
+  const r = sessionSavings(
+    { sessionId: 's-gate', transcriptPath: tp },
+    stateLate,
+    FACTORS,
+    mins(20)
+  );
+  assert.strictEqual(r.savedTokens, 0);
+});
+
+test('truncated/replaced transcript resets the cache and rescans', () => {
+  const tp = tmpTranscript([assistant(5, 100), assistant(6, 100)]);
+  const id = 's-trunc';
+  sessionSavings({ sessionId: id, transcriptPath: tp }, stateOn, FACTORS, mins(10));
+  fs.writeFileSync(tp, JSON.stringify(assistant(7, 50)) + '\n'); // smaller file
+  const r = sessionSavings({ sessionId: id, transcriptPath: tp }, stateOn, FACTORS, mins(10));
+  assert.strictEqual(r.savedTokens, 50);
+});
+
+test('milestones: crossed once, never re-reported', () => {
+  const tp = tmpTranscript([assistant(5, 6000)]); // saved = 6000 with factor 0.5
+  const id = 's-mile';
+  const r1 = sessionSavings({ sessionId: id, transcriptPath: tp }, stateOn, FACTORS, mins(10));
+  assert.deepStrictEqual(r1.crossed, [5_000]);
+  const r2 = sessionSavings({ sessionId: id, transcriptPath: tp }, stateOn, FACTORS, mins(10));
+  assert.deepStrictEqual(r2.crossed, []);
+});
+
+test('returns null for missing transcript or unsafe session id', () => {
+  assert.strictEqual(
+    sessionSavings(
+      { sessionId: 's-x', transcriptPath: '/nope/missing.jsonl' },
+      stateOn,
+      FACTORS,
+      mins(1)
+    ),
+    null
+  );
+  const tp = tmpTranscript([assistant(5, 10)]);
+  assert.strictEqual(
+    sessionSavings({ sessionId: '../evil', transcriptPath: tp }, stateOn, FACTORS, mins(1)),
+    null
+  );
+  assert.strictEqual(
+    sessionSavings({ sessionId: null, transcriptPath: tp }, stateOn, FACTORS, mins(1)),
+    null
+  );
+});
+
+test('corrupt cache file is reset, not fatal', () => {
+  const tp = tmpTranscript([assistant(5, 100)]);
+  const id = 's-corrupt';
+  fs.mkdirSync(SESSIONS_DIR, { recursive: true });
+  fs.writeFileSync(cachePath(id), '{not json!!');
+  const r = sessionSavings({ sessionId: id, transcriptPath: tp }, stateOn, FACTORS, mins(10));
+  assert.strictEqual(r.savedTokens, 100);
+});
+
+test('prunes session caches older than 30 days', () => {
+  const tp = tmpTranscript([assistant(5, 100)]);
+  fs.mkdirSync(SESSIONS_DIR, { recursive: true });
+  const old = cachePath('s-ancient');
+  fs.writeFileSync(old, '{}');
+  const past = new Date(mins(0) - 31 * 24 * 60 * 60 * 1000);
+  fs.utimesSync(old, past, past);
+  sessionSavings({ sessionId: 's-prune', transcriptPath: tp }, stateOn, FACTORS, mins(10));
+  assert.ok(!fs.existsSync(old), 'stale cache pruned');
+});
+
+test('latestSessionSaved returns newest cache savedTokens', () => {
+  const tpA = tmpTranscript([assistant(5, 100)]);
+  const tpB = tmpTranscript([assistant(5, 200)]);
+  sessionSavings({ sessionId: 's-old', transcriptPath: tpA }, stateOn, FACTORS, mins(10));
+  const past = new Date(mins(0) - 60_000);
+  fs.utimesSync(cachePath('s-old'), past, past);
+  sessionSavings({ sessionId: 's-new', transcriptPath: tpB }, stateOn, FACTORS, mins(10));
+  assert.strictEqual(latestSessionSaved(), 200);
+});

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -13,7 +13,6 @@ test('readState returns default when file missing', () => {
   assert.deepStrictEqual(s, {
     current: 'off',
     events: [],
-    cache: null,
     buddy: {},
     promptsSinceReinject: 0,
   });
@@ -23,7 +22,6 @@ test('writeState then readState round-trips', () => {
   state.writeState({
     current: 'full',
     events: [{ ts: 'T', level: 'full' }],
-    cache: null,
     buddy: {},
   });
   assert.strictEqual(state.readState().current, 'full');
@@ -36,7 +34,7 @@ test('readState survives corrupt file', () => {
 });
 
 test('update applies mutation and persists', () => {
-  state.writeState({ current: 'off', events: [], cache: null, buddy: {} });
+  state.writeState({ current: 'off', events: [], buddy: {} });
   const next = state.update((s) => {
     s.current = 'ultra';
     return s;

--- a/test/stats-lib.test.js
+++ b/test/stats-lib.test.js
@@ -5,6 +5,7 @@ const {
   attribute,
   estimateSaved,
   crossedMilestones,
+  MILESTONES,
 } = require('../scripts/lib/stats-lib');
 
 const T0 = Date.parse('2026-07-01T10:00:00Z');
@@ -66,8 +67,12 @@ test('estimateSaved applies per-level factors', () => {
   assert.strictEqual(saved, 100); // 100/(1-0.5) - 100
 });
 
+test('MILESTONES are session-scale', () => {
+  assert.deepStrictEqual(MILESTONES, [5_000, 10_000, 25_000, 50_000, 100_000]);
+});
+
 test('crossedMilestones', () => {
   assert.deepStrictEqual(crossedMilestones(9000, 11_000), [10_000]);
   assert.deepStrictEqual(crossedMilestones(11_000, 12_000), []);
-  assert.deepStrictEqual(crossedMilestones(0, 60_000), [10_000, 50_000]);
+  assert.deepStrictEqual(crossedMilestones(0, 60_000), [5_000, 10_000, 25_000, 50_000]);
 });

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -105,3 +105,51 @@ test('collectMessages attributes sessionStartMs per session across multiple proj
   const sess2Message = messages.find((m) => m.outputTokens === 3);
   assert.strictEqual(sess2Message.sessionStartMs, Date.parse('2026-07-02T11:00:00.000Z'));
 });
+
+const { execFileSync } = require('node:child_process');
+
+const STATS_SCRIPT = path.join(__dirname, '..', 'scripts', 'stats.js');
+
+function statsEnv() {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-statscli-'));
+  const projectsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-proj-'));
+  fs.writeFileSync(
+    path.join(stateDir, 'state.json'),
+    JSON.stringify({
+      current: 'full',
+      events: [{ ts: '2026-07-08T09:00:00.000Z', level: 'full' }],
+      buddy: {},
+    })
+  );
+  return {
+    stateDir,
+    env: { ...process.env, ERIDIAN_STATE_DIR: stateDir, CLAUDE_PROJECTS_DIR: projectsDir },
+  };
+}
+
+test('stats CLI prints (no data) session line when no session cache exists', () => {
+  const { env } = statsEnv();
+  const out = execFileSync('node', [STATS_SCRIPT], { env }).toString();
+  assert.match(out, /this session: \(no data\)/);
+  assert.match(out, /lifetime \(all sessions\):/);
+});
+
+test('stats CLI prints formatted session savings from newest session cache', () => {
+  const { stateDir, env } = statsEnv();
+  const sessionsDir = path.join(stateDir, 'sessions');
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  fs.writeFileSync(path.join(sessionsDir, 'sess-1.json'), JSON.stringify({ savedTokens: 2100 }));
+  const out = execFileSync('node', [STATS_SCRIPT], { env }).toString();
+  assert.match(out, /this session: ~2\.1k saved \(full\)/);
+});
+
+test('stats CLI no longer writes a lifetime cache or milestone into state', () => {
+  const { stateDir, env } = statsEnv();
+  execFileSync('node', [STATS_SCRIPT], { env });
+  const state = JSON.parse(fs.readFileSync(path.join(stateDir, 'state.json'), 'utf8'));
+  assert.ok(!('cache' in state) || state.cache === null, 'no cache written');
+  assert.ok(!state.buddy?.milestoneAt, 'no milestone stamped');
+  assert.ok(
+    !execFileSync('node', [STATS_SCRIPT], { env }).toString().includes('milestone crossed')
+  );
+});

--- a/test/statusline.test.js
+++ b/test/statusline.test.js
@@ -9,15 +9,15 @@ test('renders nothing when off', () => {
 });
 
 test('3 rows, quip on the top row, level+savings on the body row', () => {
-  const lines = renderLines({ current: 'full', buddy: {}, cache: { savedTokens: 12300 } }, NOW);
+  const lines = renderLines({ current: 'full', buddy: {} }, NOW, 12300);
   assert.strictEqual(lines.length, 3);
   assert.match(lines[0], /♫/);
   assert.match(lines[1], /∙\s*full/);
   assert.match(lines[1], /~12\.3k saved/);
 });
 
-test('omits savings segment without cache', () => {
-  const lines = renderLines({ current: 'lite', buddy: {}, cache: null }, NOW);
+test('omits savings segment when session savings unavailable', () => {
+  const lines = renderLines({ current: 'lite', buddy: {} }, NOW, null);
   assert.ok(lines.every((l) => !l.includes('saved')));
   assert.ok(lines.some((l) => /lite/.test(l)));
 });
@@ -26,4 +26,70 @@ test('formatTokens', () => {
   assert.strictEqual(formatTokens(900), '900');
   assert.strictEqual(formatTokens(12300), '12.3k');
   assert.strictEqual(formatTokens(1500000), '1.5M');
+});
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'statusline.js');
+
+function cliEnv() {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-sl-'));
+  fs.writeFileSync(
+    path.join(stateDir, 'state.json'),
+    JSON.stringify({
+      current: 'full',
+      events: [{ ts: '2026-07-08T09:00:00.000Z', level: 'full' }],
+      buddy: {},
+    })
+  );
+  return { stateDir, env: { ...process.env, ERIDIAN_STATE_DIR: stateDir } };
+}
+
+test('CLI: renders session savings from stdin session JSON', () => {
+  const { stateDir, env } = cliEnv();
+  const transcript = path.join(stateDir, 'transcript.jsonl');
+  fs.writeFileSync(
+    transcript,
+    JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-07-08T10:00:00.000Z',
+      message: { usage: { output_tokens: 1000 } },
+    }) + '\n'
+  );
+  const out = execFileSync('node', [SCRIPT], {
+    env,
+    input: JSON.stringify({ session_id: 'cli-sess', transcript_path: transcript }),
+  }).toString();
+  assert.match(out, /saved/);
+});
+
+test('CLI: empty stdin still renders the buddy, without savings', () => {
+  const { env } = cliEnv();
+  const out = execFileSync('node', [SCRIPT], { env, input: '' }).toString();
+  assert.match(out, /full/);
+  assert.ok(!out.includes('saved'));
+});
+
+test('CLI: milestone crossing stamps buddy.milestoneAt', () => {
+  const { stateDir, env } = cliEnv();
+  const transcript = path.join(stateDir, 'transcript.jsonl');
+  // full factor is 0.26 → saved = tokens/(1-0.26) - tokens ≈ 0.351*tokens;
+  // 20000 tokens ≈ 7027 saved → crosses the 5k milestone
+  fs.writeFileSync(
+    transcript,
+    JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-07-08T10:00:00.000Z',
+      message: { usage: { output_tokens: 20000 } },
+    }) + '\n'
+  );
+  execFileSync('node', [SCRIPT], {
+    env,
+    input: JSON.stringify({ session_id: 'cli-mile', transcript_path: transcript }),
+  });
+  const state = JSON.parse(fs.readFileSync(path.join(stateDir, 'state.json'), 'utf8'));
+  assert.ok(state.buddy.milestoneAt, 'milestoneAt stamped');
 });


### PR DESCRIPTION
## Summary
- statusline now shows the **current session's** estimated savings, computed live from the session transcript (incremental byte-offset scan, per-session cache in `~/.claude/eridian/sessions/`)
- session-scale milestones (5k/10k/25k/50k/100k) trigger the buddy dance automatically; lifetime milestones retired
- `/eridian:stats` prepends a `this session:` line and keeps the lifetime table; it no longer writes a cache
- custom statusline wrappers must forward Claude Code's stdin JSON (README documents this)

## Test plan
- [x] npm test (unit + CLI integration tests for session-savings, statusline stdin path, stats output)
- [x] npm run lint / format:check
- [ ] live check: statusline savings tick up during a session; buddy dances at 5k

🤖 Generated with [Claude Code](https://claude.com/claude-code)