### PR TITLE
feat: step buddy per refresh, with configurable step rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ from the session transcript on every statusline refresh. Rocky dances when
 the session crosses a savings milestone (5k/10k/25k/50k/100k). Lifetime
 totals live in `/eridian:stats`.
 
-Rocky animates whenever Claude Code refreshes the statusline (i.e. while
-the conversation is active); when you idle, the last frame stays put until
-the next refresh — that cadence is the host's, not Rocky's.
+Rocky steps one animation frame per statusline refresh: every time Claude
+Code re-runs the statusline (a handful of seconds apart while the
+conversation is active), the pose visibly changes. When you idle, the last
+frame stays put until the next refresh — that cadence is the host's, not
+Rocky's.
 
 Using your own statusline script instead of the generated one? Forward the
 JSON that Claude Code pipes on stdin, or the savings segment is omitted:

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ see [Credits](#credits).
 
 ## Use
 
-| Command                           | What it does                                         |
-| --------------------------------- | ---------------------------------------------------- |
-| `/eridian:mode`                   | toggle eridian mode (full) on/off                    |
-| `/eridian:mode lite\|full\|ultra` | set intensity (`eridian` = `ultra`)                  |
-| `/eridian:stats`                  | estimated token savings + statusline setup           |
-| `/eridian:commit`                 | terse conventional commit from staged diff           |
-| `/eridian:review`                 | one-line-per-finding review. `not ship. fix first.`  |
-| `/eridian:compress`               | compress CLAUDE.md to cut input tokens (backup kept) |
+| Command                           | What it does                                                  |
+| --------------------------------- | ------------------------------------------------------------- |
+| `/eridian:mode`                   | toggle eridian mode (full) on/off                             |
+| `/eridian:mode lite\|full\|ultra` | set intensity (`eridian` = `ultra`)                           |
+| `/eridian:stats`                  | estimated token savings + statusline setup                    |
+| `/eridian:buddy <seconds>`        | slow the buddy: min seconds between steps (0 = every refresh) |
+| `/eridian:commit`                 | terse conventional commit from staged diff                    |
+| `/eridian:review`                 | one-line-per-finding review. `not ship. fix first.`           |
+| `/eridian:compress`               | compress CLAUDE.md to cut input tokens (backup kept)          |
 
 Or just say "talk like Rocky". Mode persists across sessions until
 `/eridian:mode off`.
@@ -61,6 +62,10 @@ Code re-runs the statusline (a handful of seconds apart while the
 conversation is active), the pose visibly changes. When you idle, the last
 frame stays put until the next refresh — that cadence is the host's, not
 Rocky's.
+
+Too jumpy? `/eridian:buddy 2` slows him to at most one step every 2
+seconds; `/eridian:buddy 0` restores per-refresh stepping. He can never
+step _faster_ than the host refreshes — physics.
 
 Using your own statusline script instead of the generated one? Forward the
 JSON that Claude Code pipes on stdin, or the savings segment is omitted:

--- a/commands/buddy.md
+++ b/commands/buddy.md
@@ -1,0 +1,12 @@
+---
+description: Set buddy animation speed (seconds between pose steps; 0 = every refresh)
+argument-hint: "[seconds]"
+allowed-tools: Bash(node:*)
+---
+
+Buddy speed result:
+
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/buddy-speed.js" $ARGUMENTS`
+
+Relay the result above to the user in one short line. If it shows
+`bad value`, relay the usage line.

--- a/scripts/buddy-speed.js
+++ b/scripts/buddy-speed.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+const { readState, update } = require('./lib/state');
+
+const arg = (process.argv[2] || '').trim();
+
+function describe(stepSeconds) {
+  const secs = Number(stepSeconds);
+  return Number.isFinite(secs) && secs > 0
+    ? `buddy steps every ${secs}s at most (host refresh permitting)`
+    : 'buddy steps every refresh (default)';
+}
+
+if (!arg) {
+  console.log(describe((readState().buddy || {}).stepSeconds));
+  process.exit(0);
+}
+
+const secs = Number(arg);
+if (!Number.isFinite(secs) || secs < 0) {
+  console.log(`bad value "${arg}". use: /eridian:buddy <seconds>, 0 = every refresh`);
+  process.exit(0);
+}
+
+update((s) => {
+  s.buddy = s.buddy || {};
+  if (secs > 0) s.buddy.stepSeconds = secs;
+  else delete s.buddy.stepSeconds;
+  return s;
+});
+
+console.log(`${describe(secs)}. good.`);
+process.exit(0);

--- a/scripts/lib/buddy.js
+++ b/scripts/lib/buddy.js
@@ -21,14 +21,17 @@ const QUIPS = {
   },
 };
 
-// Per mood: which arm poses cycle, how fast, and special flags.
-// still = frozen figure; tucked = asleep; fastGait = 1s legs;
+// Per mood: which arm poses cycle, and special flags. Poses advance one
+// step per statusline refresh (buddy.frame, bumped by statusline.js) —
+// the host re-runs the statusline too rarely (~10s) for wall-clock ticks
+// to ever be seen, so the frame counter is the only animation clock.
+// still = frozen figure; tucked = asleep;
 // dance = synced arms+legs+shift cycle (celebrating only).
 const ANIM = {
-  humming: { arms: ['down', 'up'], armsTick: 2000 },
-  reacting: { arms: ['leftWave', 'rightWave'], armsTick: 600 },
-  working: { arms: ['up', 'wide'], armsTick: 1000, fastGait: true },
-  celebrating: { dance: true, tick: 500 },
+  humming: { arms: ['down', 'up'] },
+  reacting: { arms: ['leftWave', 'rightWave'] },
+  working: { arms: ['up', 'wide'] },
+  celebrating: { dance: true },
   alarmed: { arms: ['up'], still: true },
   sleeping: { tucked: true },
 };
@@ -67,17 +70,16 @@ function pick(pool, nowMs) {
 }
 
 // arms drift through the mood's poses; a single/still pose never changes
-function armFrame(anim, nowMs) {
+function armFrame(anim, frame) {
   const poses = anim.arms;
   if (anim.still || poses.length === 1) return poses[0];
-  return poses[Math.floor(nowMs / anim.armsTick) % poses.length];
+  return poses[frame % poses.length];
 }
 
-// legs step every 2s; twice as fast while working; frozen when still
-function gaitIndex(anim, nowMs) {
+// legs alternate gait frames each refresh; frozen when still
+function gaitIndex(anim, frame) {
   if (anim.still) return 0;
-  const tick = anim.fastGait ? 1000 : 2000;
-  return Math.floor(nowMs / tick) % 2;
+  return frame % 2;
 }
 
 function quipFor(mood, buddy, nowMs) {
@@ -104,13 +106,14 @@ function renderBuddy(buddy = {}, nowMs) {
   const mood = deriveMood(buddy, nowMs);
   const anim = ANIM[mood];
   const quip = quipFor(mood, buddy, nowMs);
+  const frame = buddy.frame || 0;
 
   if (anim.tucked) {
     return { rows: [MINI.dome, MINI.body, MINI.legsTucked], quip };
   }
 
   if (anim.dance) {
-    const beat = DANCE_BEATS[Math.floor(nowMs / anim.tick) % DANCE_BEATS.length];
+    const beat = DANCE_BEATS[frame % DANCE_BEATS.length];
     const pad = ' '.repeat(beat.shift);
     return {
       rows: [
@@ -122,8 +125,8 @@ function renderBuddy(buddy = {}, nowMs) {
     };
   }
 
-  const arms = MINI.arms[armFrame(anim, nowMs)];
-  const legs = MINI.legs[gaitIndex(anim, nowMs)];
+  const arms = MINI.arms[armFrame(anim, frame)];
+  const legs = MINI.legs[gaitIndex(anim, frame)];
   return { rows: [merge(arms, MINI.dome), MINI.body, legs], quip };
 }
 

--- a/scripts/lib/state.js
+++ b/scripts/lib/state.js
@@ -31,13 +31,19 @@ const DEFAULT_STATE = {
   promptsSinceReinject: 0,
 };
 
+// state fields written by old versions but no longer read by anything;
+// dropped on read so the next write cleans the file
+const RETIRED_KEYS = ['buddyStyle'];
+
 function readState() {
   try {
     const parsed = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
       return structuredClone(DEFAULT_STATE);
     }
-    return { ...structuredClone(DEFAULT_STATE), ...parsed };
+    const state = { ...structuredClone(DEFAULT_STATE), ...parsed };
+    for (const key of RETIRED_KEYS) delete state[key];
+    return state;
   } catch {
     return structuredClone(DEFAULT_STATE);
   }

--- a/scripts/statusline.js
+++ b/scripts/statusline.js
@@ -39,9 +39,10 @@ if (require.main === module) {
   const render = (raw) => {
     try {
       const { readState, update } = require('./lib/state');
-      const state = readState();
+      let state = readState();
       const nowMs = Date.now();
       let savedTokens = null;
+      let crossedMilestone = false;
       try {
         const input = JSON.parse(raw);
         const fs = require('node:fs');
@@ -58,15 +59,20 @@ if (require.main === module) {
         );
         if (result) {
           savedTokens = result.savedTokens;
-          if (result.crossed.length) {
-            update((s) => {
-              s.buddy.milestoneAt = new Date(nowMs).toISOString();
-              return s;
-            });
-          }
+          crossedMilestone = result.crossed.length > 0;
         }
       } catch {
         // no/garbage stdin or unreadable transcript — render without savings
+      }
+      // each host refresh advances the animation one frame — the frame
+      // counter, not wall clock, is the buddy's clock (see lib/buddy.js)
+      if (state.current && state.current !== 'off') {
+        state = update((s) => {
+          s.buddy = s.buddy || {};
+          s.buddy.frame = (s.buddy.frame || 0) + 1;
+          if (crossedMilestone) s.buddy.milestoneAt = new Date(nowMs).toISOString();
+          return s;
+        });
       }
       process.stdout.write(renderLines(state, nowMs, savedTokens).join('\n'));
     } catch {

--- a/scripts/statusline.js
+++ b/scripts/statusline.js
@@ -65,11 +65,19 @@ if (require.main === module) {
         // no/garbage stdin or unreadable transcript — render without savings
       }
       // each host refresh advances the animation one frame — the frame
-      // counter, not wall clock, is the buddy's clock (see lib/buddy.js)
+      // counter, not wall clock, is the buddy's clock (see lib/buddy.js).
+      // buddy.stepSeconds (set via /eridian:buddy) throttles the advance to
+      // at most once per that many seconds; 0/absent/invalid = every refresh.
       if (state.current && state.current !== 'off') {
         state = update((s) => {
           s.buddy = s.buddy || {};
-          s.buddy.frame = (s.buddy.frame || 0) + 1;
+          const secs = Number(s.buddy.stepSeconds);
+          const stepMs = Number.isFinite(secs) && secs > 0 ? secs * 1000 : 0;
+          const last = Date.parse(s.buddy.lastStepAt);
+          if (!stepMs || !Number.isFinite(last) || nowMs - last >= stepMs) {
+            s.buddy.frame = (s.buddy.frame || 0) + 1;
+            s.buddy.lastStepAt = new Date(nowMs).toISOString();
+          }
           if (crossedMilestone) s.buddy.milestoneAt = new Date(nowMs).toISOString();
           return s;
         });

--- a/test/buddy-speed.test.js
+++ b/test/buddy-speed.test.js
@@ -1,0 +1,71 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'buddy-speed.js');
+
+function run(args, stateDir) {
+  return execFileSync('node', [SCRIPT, ...args], {
+    env: { ...process.env, ERIDIAN_STATE_DIR: stateDir },
+    encoding: 'utf8',
+  });
+}
+
+function freshDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'eridian-buddy-speed-'));
+}
+
+function readBuddy(dir) {
+  return JSON.parse(fs.readFileSync(path.join(dir, 'state.json'), 'utf8')).buddy;
+}
+
+test('sets stepSeconds', () => {
+  const dir = freshDir();
+  const out = run(['2'], dir);
+  assert.match(out, /every 2s/);
+  assert.strictEqual(readBuddy(dir).stepSeconds, 2);
+});
+
+test('accepts fractional seconds', () => {
+  const dir = freshDir();
+  run(['0.5'], dir);
+  assert.strictEqual(readBuddy(dir).stepSeconds, 0.5);
+});
+
+test('0 removes the setting', () => {
+  const dir = freshDir();
+  run(['2'], dir);
+  const out = run(['0'], dir);
+  assert.match(out, /every refresh/);
+  assert.ok(!('stepSeconds' in readBuddy(dir)));
+});
+
+test('no arg prints current setting', () => {
+  const dir = freshDir();
+  assert.match(run([], dir), /every refresh/);
+  run(['3'], dir);
+  assert.match(run([], dir), /every 3s/);
+});
+
+test('rejects garbage and negatives, state untouched', () => {
+  const dir = freshDir();
+  assert.match(run(['fast'], dir), /bad value/);
+  assert.match(run(['-1'], dir), /bad value/);
+  assert.ok(!fs.existsSync(path.join(dir, 'state.json')));
+});
+
+test('preserves other buddy fields', () => {
+  const dir = freshDir();
+  fs.writeFileSync(
+    path.join(dir, 'state.json'),
+    JSON.stringify({ current: 'full', events: [], buddy: { frame: 7 } })
+  );
+  run(['2'], dir);
+  const buddy = readBuddy(dir);
+  assert.strictEqual(buddy.frame, 7);
+  assert.strictEqual(buddy.stepSeconds, 2);
+});

--- a/test/buddy.test.js
+++ b/test/buddy.test.js
@@ -66,9 +66,8 @@ test('sleeping tucks the legs and drops arms; dome shows through plain', () => {
 
 test('celebrating dances: two synced beats, whole figure shifts one column together', () => {
   const buddy = { milestoneAt: secsAgo(5) };
-  const t0 = Math.floor(NOW / 1000) * 1000; // aligned so beat index is 0 (celebrate, shift 0)
-  const beat0 = renderBuddy(buddy, t0).rows;
-  const beat1 = renderBuddy(buddy, t0 + 500).rows; // beat index 1 (five, shift 1)
+  const beat0 = renderBuddy({ ...buddy, frame: 0 }, NOW).rows;
+  const beat1 = renderBuddy({ ...buddy, frame: 1 }, NOW).rows; // beat index 1 (five, shift 1)
   assert.notDeepStrictEqual(beat0, beat1, 'beats differ (different arm pose + leg frame)');
   // body row content doesn't depend on pose, so it isolates the shift
   assert.strictEqual(beat1[1], ` ${beat0[1]}`, 'beat 1 shifts the whole figure one column right');
@@ -85,19 +84,34 @@ test('celebrating dances: two synced beats, whole figure shifts one column toget
   );
 });
 
-test('alarmed is held still across ticks; humming animates', () => {
-  const alarmed = { lastErrorAt: secsAgo(5) };
-  assert.deepStrictEqual(
-    renderBuddy(alarmed, NOW).rows,
-    renderBuddy(alarmed, NOW + 3000).rows,
-    'alarmed frozen (stillness reads as alarm)'
-  );
+test('alarmed is held still across frames; sleeping too', () => {
+  for (const mood of ['alarmed', 'sleeping']) {
+    assert.deepStrictEqual(
+      renderBuddy({ ...MOODS[mood], frame: 0 }, NOW).rows,
+      renderBuddy({ ...MOODS[mood], frame: 1 }, NOW).rows,
+      `${mood} frozen`
+    );
+  }
+});
 
-  const t0 = Math.floor(NOW / 4000) * 4000; // arms & legs both flip within 2s
-  assert.notDeepStrictEqual(
-    renderBuddy({}, t0).rows,
-    renderBuddy({}, t0 + 2000).rows,
-    'humming moves'
+// the original bug: poses were keyed to wall clock, but the host only
+// re-runs the statusline every ~10s, so sub-2s ticks never showed. Poses
+// must advance with the per-invocation frame counter instead.
+test('every moving mood steps a visibly different frame each refresh', () => {
+  for (const mood of ['humming', 'reacting', 'working', 'celebrating']) {
+    assert.notDeepStrictEqual(
+      renderBuddy({ ...MOODS[mood], frame: 0 }, NOW).rows,
+      renderBuddy({ ...MOODS[mood], frame: 1 }, NOW).rows,
+      `${mood} moves between consecutive frames`
+    );
+  }
+});
+
+test('pose is keyed to frame, not wall clock', () => {
+  assert.deepStrictEqual(
+    renderBuddy({ frame: 4 }, NOW).rows,
+    renderBuddy({ frame: 4 }, NOW + 3000).rows,
+    'same frame renders the same pose regardless of clock'
   );
 });
 
@@ -106,12 +120,11 @@ test('reacting quip follows prompt class', () => {
   assert.strictEqual(renderBuddy(buddy, NOW).quip, 'bad bad. I fix.');
 });
 
-test('working legs step faster than humming', () => {
-  const t0 = Math.floor(NOW / 2000) * 2000;
+test('legs alternate gait frames with the frame counter', () => {
   const work = { lastToolAt: secsAgo(1) };
   assert.notStrictEqual(
-    renderBuddy(work, t0).rows[2],
-    renderBuddy(work, t0 + 1000).rows[2],
-    'working gait alternates every second'
+    renderBuddy({ ...work, frame: 0 }, NOW).rows[2],
+    renderBuddy({ ...work, frame: 1 }, NOW).rows[2],
+    'gait alternates every frame'
   );
 });

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -28,6 +28,11 @@ test('writeState then readState round-trips', () => {
   assert.strictEqual(state.readState().events.length, 1);
 });
 
+test('readState prunes retired keys from old state files', () => {
+  state.writeState({ current: 'full', events: [], buddy: {}, buddyStyle: 'tall' });
+  assert.ok(!('buddyStyle' in state.readState()), 'buddyStyle pruned');
+});
+
 test('readState survives corrupt file', () => {
   fs.writeFileSync(state.STATE_FILE, '{not json!!');
   assert.strictEqual(state.readState().current, 'off');

--- a/test/statusline.test.js
+++ b/test/statusline.test.js
@@ -91,6 +91,50 @@ test('CLI: off mode leaves buddy.frame untouched', () => {
   assert.ok(!('frame' in JSON.parse(fs.readFileSync(stateFile, 'utf8')).buddy));
 });
 
+test('CLI: buddy.stepSeconds holds the frame between rapid refreshes', () => {
+  const { stateDir, env } = cliEnv();
+  const stateFile = path.join(stateDir, 'state.json');
+  fs.writeFileSync(
+    stateFile,
+    JSON.stringify({ current: 'full', events: [], buddy: { stepSeconds: 60 } })
+  );
+  execFileSync('node', [SCRIPT], { env, input: '' });
+  const after1 = JSON.parse(fs.readFileSync(stateFile, 'utf8')).buddy;
+  assert.strictEqual(after1.frame, 1, 'first refresh steps (no lastStepAt yet)');
+  assert.ok(after1.lastStepAt, 'lastStepAt stamped');
+  execFileSync('node', [SCRIPT], { env, input: '' });
+  const after2 = JSON.parse(fs.readFileSync(stateFile, 'utf8')).buddy;
+  assert.strictEqual(after2.frame, 1, 'second refresh within 60s holds the frame');
+  assert.strictEqual(after2.lastStepAt, after1.lastStepAt, 'lastStepAt unchanged on hold');
+});
+
+test('CLI: stale lastStepAt advances the frame', () => {
+  const { stateDir, env } = cliEnv();
+  const stateFile = path.join(stateDir, 'state.json');
+  fs.writeFileSync(
+    stateFile,
+    JSON.stringify({
+      current: 'full',
+      events: [],
+      buddy: { stepSeconds: 60, frame: 4, lastStepAt: '2020-01-01T00:00:00.000Z' },
+    })
+  );
+  execFileSync('node', [SCRIPT], { env, input: '' });
+  assert.strictEqual(JSON.parse(fs.readFileSync(stateFile, 'utf8')).buddy.frame, 5);
+});
+
+test('CLI: invalid stepSeconds steps every refresh', () => {
+  const { stateDir, env } = cliEnv();
+  const stateFile = path.join(stateDir, 'state.json');
+  fs.writeFileSync(
+    stateFile,
+    JSON.stringify({ current: 'full', events: [], buddy: { stepSeconds: 'fast' } })
+  );
+  execFileSync('node', [SCRIPT], { env, input: '' });
+  execFileSync('node', [SCRIPT], { env, input: '' });
+  assert.strictEqual(JSON.parse(fs.readFileSync(stateFile, 'utf8')).buddy.frame, 2);
+});
+
 test('CLI: milestone crossing stamps buddy.milestoneAt', () => {
   const { stateDir, env } = cliEnv();
   const transcript = path.join(stateDir, 'transcript.jsonl');

--- a/test/statusline.test.js
+++ b/test/statusline.test.js
@@ -73,6 +73,24 @@ test('CLI: empty stdin still renders the buddy, without savings', () => {
   assert.ok(!out.includes('saved'));
 });
 
+test('CLI: each invocation advances buddy.frame and the rendered pose', () => {
+  const { stateDir, env } = cliEnv();
+  const stateFile = path.join(stateDir, 'state.json');
+  const out1 = execFileSync('node', [SCRIPT], { env, input: '' }).toString();
+  assert.strictEqual(JSON.parse(fs.readFileSync(stateFile, 'utf8')).buddy.frame, 1);
+  const out2 = execFileSync('node', [SCRIPT], { env, input: '' }).toString();
+  assert.strictEqual(JSON.parse(fs.readFileSync(stateFile, 'utf8')).buddy.frame, 2);
+  assert.notStrictEqual(out1, out2, 'consecutive refreshes render different poses');
+});
+
+test('CLI: off mode leaves buddy.frame untouched', () => {
+  const { stateDir, env } = cliEnv();
+  const stateFile = path.join(stateDir, 'state.json');
+  fs.writeFileSync(stateFile, JSON.stringify({ current: 'off', events: [], buddy: {} }));
+  execFileSync('node', [SCRIPT], { env, input: '' });
+  assert.ok(!('frame' in JSON.parse(fs.readFileSync(stateFile, 'utf8')).buddy));
+});
+
 test('CLI: milestone crossing stamps buddy.milestoneAt', () => {
   const { stateDir, env } = cliEnv();
   const transcript = path.join(stateDir, 'transcript.jsonl');


### PR DESCRIPTION
## Problem

Rocky looked frozen. Animation poses were keyed to wall-clock ticks (0.5–2s), but Claude Code only re-runs the statusline every ~8–11s during activity (measured by instrumenting the wrapper). Sub-2s ticks sampled every ~10s = coin-flip pose changes at best, fully frozen when idle. The fast moods (reacting 600ms, celebrating 500ms) played entire cycles between refreshes — invisible.

## Fix

- `buddy.frame` counter in state; `statusline.js` bumps it once per invocation (skipped when mode is off), merged into the same `update()` as the milestone stamp.
- `renderBuddy` keys arm poses, gait, and dance beats off the frame counter — **every host refresh now visibly changes the pose**. Mood windows and quip rotation stay wall-clock.
- `armsTick`/`fastGait`/`tick` config removed — per-mood speed differences were meaningless at ~10s sampling.
- `readState()` prunes the retired `buddyStyle` key (left behind by a97d039); next write self-cleans old state files.
- README cadence note updated.

## Step rate setting (new)

Per-refresh stepping can look frantic during fast refresh bursts, so "how often Rocky steps" is now configurable:

- `buddy.stepSeconds` in state throttles the frame bump: advance at most once per that many seconds, stamped in `buddy.lastStepAt`. `0`/absent/invalid = every refresh (default, unchanged behavior).
- New `/eridian:buddy <seconds>` command (`scripts/buddy-speed.js` + `commands/buddy.md`, mirrors `mode.js`): set, `0` to reset, no arg prints current, rejects garbage/negatives.
- Rocky can only slow relative to host cadence, never speed up — the statusline can't run itself.

## Verification

- TDD: throttle + command tests watched failing first, then green — 126/126 pass, lint + prettier clean.
- End-to-end: real statusline wrapper run 3× back-to-back — pose flips on every consecutive invocation; with `/eridian:buddy 2`, three rapid refreshes hold the frame and a refresh after 2.1s advances it; reset restores per-refresh stepping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)