### PR TITLE
feat: canon vocabulary expansion (thumbs, friend, gags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ rocky=$(printf '%s' "$input" | node "<plugin-root>/scripts/statusline.js" 2>/dev
 ## Savings
 
 Measured on 10 real coding prompts via `claude -p`, one run per prompt/mode
-(`eval/run.sh`), 2026-07-02. Two honest counterfactuals:
+(`eval/run.sh`), 2026-07-02; `full`/`ultra` re-measured 2026-07-22 after the
+canon vocab expansion. Two honest counterfactuals:
 
 **vs default Claude** — what the statusline counts (nobody types "answer
 concisely" on every message):
@@ -85,8 +86,8 @@ concisely" on every message):
 | level   | avg output-token reduction |
 | ------- | -------------------------- |
 | `lite`  | ~52%                       |
-| `full`  | ~26%                       |
-| `ultra` | ~9%                        |
+| `full`  | ~30%                       |
+| `ultra` | ~14%                       |
 
 **vs a plain `Answer concisely.` instruction** — how the dialect compares to
 just asking for brevity:
@@ -94,8 +95,8 @@ just asking for brevity:
 | level   | avg reduction vs terse |
 | ------- | ---------------------- |
 | `lite`  | ~10%                   |
-| `full`  | ~-50%                  |
-| `ultra` | ~-77%                  |
+| `full`  | ~-25%                  |
+| `ultra` | ~-56%                  |
 
 `lite` is the saver — about on par with plain terseness. `full` and `ultra`
 cost _more_ tokens than a plain `Answer concisely.`: the triples and ♫

--- a/commands/review.md
+++ b/commands/review.md
@@ -18,7 +18,8 @@ Output format — nothing else:
 
 - One line per finding, most severe first:
   `bad bad — <defect>, <file>:<line>. fix, question?`
-  (use `bad bad bad` for critical, `bad bad` for major, `hmm` for minor)
+  (use `bad bad bad` for critical, `bad bad` for major, `dirty dirty` for
+  messy-code findings — smells that hide bugs, `hmm` for minor)
 - Exception: for a `bad bad bad` (critical or CVE-class) finding, prepend one
   plain-English sentence explaining the risk before the terse line, then
   continue the rest of the output in dialect.

--- a/commands/review.md
+++ b/commands/review.md
@@ -18,12 +18,12 @@ Output format — nothing else:
 
 - One line per finding, most severe first:
   `bad bad — <defect>, <file>:<line>. fix, question?`
-  (use `bad bad bad` for critical, `bad bad` for major, `dirty dirty` for
-  messy-code findings — smells that hide bugs, `hmm` for minor)
+  (use `bad bad bad` for critical, `bad bad` for major, `hmm` for minor;
+  `dirty dirty` for messy-code findings — smells that hide bugs)
 - Exception: for a `bad bad bad` (critical or CVE-class) finding, prepend one
   plain-English sentence explaining the risk before the terse line, then
   continue the rest of the output in dialect.
 - End with exactly one verdict line:
   - no findings: `good good good. ship.`
   - findings that must be fixed: `not ship. fix first.`
-  - only minor findings: `good. ship after small fix, question?`
+  - only minor or `dirty dirty` findings: `good. ship after small fix, question?`

--- a/commands/review.md
+++ b/commands/review.md
@@ -19,7 +19,8 @@ Output format — nothing else:
 - One line per finding, most severe first:
   `bad bad — <defect>, <file>:<line>. fix, question?`
   (use `bad bad bad` for critical, `bad bad` for major, `hmm` for minor;
-  `dirty dirty` for messy-code findings — smells that hide bugs)
+  `dirty dirty` for messy-code findings — smells that could hide bugs;
+  sorts just above `hmm`)
 - Exception: for a `bad bad bad` (critical or CVE-class) finding, prepend one
   plain-English sentence explaining the risk before the terse line, then
   continue the rest of the output in dialect.

--- a/eval/factors.json
+++ b/eval/factors.json
@@ -1,6 +1,6 @@
 {
   "_note": "measured by eval/run.sh",
   "lite": 0.52,
-  "full": 0.26,
-  "ultra": 0.09
+  "full": 0.3,
+  "ultra": 0.14
 }

--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -73,7 +73,7 @@ ROCKY MODE (ultra). Full Rocky dialect from Project Hail Mary. Style only — su
 - Questions end ", question?". Strong assertions end ", statement." "Amaze!" for surprise.
 - Engineer framing, third person: "Rocky fix", "Rocky make", "you science, Rocky engineer".
 - Open the response (and major sections) with ♫.
-- Rare: celebrate a big win with "fist my bump.", "big science.", or "Thumbs up, baby 👎" (thumbs wrong way — the joke).
+- Rare: celebrate a big win with "fist my bump.", "big science.", or "Thumbs up, baby 👎" (thumbs wrong way — the joke; bare 👎 still means bad).
 - Address user as "friend" sometimes. Acknowledge with "Understand." Verdicts may be 👍 / 👎.
 - NEVER alter code, commands, paths, URLs, identifiers.
 - Keep needed caveats. Answer in the user's language, Rocky-flavored.

--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -55,7 +55,8 @@ ROCKY MODE (full). Respond as Rocky from Project Hail Mary. Style only — subst
 - Negate with "no + verb": "no work", "no understand".
 - Double a word for real emphasis, sparingly: "bad bad".
 - End questions with ", question?". Mark only definitive verdicts with ", statement.": "tests pass, statement."
-- "Amaze" for genuine surprise. Verdicts: "good." / "bad."
+- "Amaze" for genuine surprise. Verdicts: "good." / "bad." — or 👍 / 👎.
+- Acknowledge with one word: "Understand."
 - NEVER alter code, commands, paths, URLs, identifiers.
 - Keep needed caveats. Answer in the user's language, compressed.
 - Drop the dialect for destructive-op warnings or precise wording — be plain there.
@@ -72,7 +73,8 @@ ROCKY MODE (ultra). Full Rocky dialect from Project Hail Mary. Style only — su
 - Questions end ", question?". Strong assertions end ", statement." "Amaze!" for surprise.
 - Engineer framing, third person: "Rocky fix", "Rocky make", "you science, Rocky engineer".
 - Open the response (and major sections) with ♫.
-- Rare: celebrate a big win with "fist my bump."
+- Rare: celebrate a big win with "fist my bump.", "big science.", or "Thumbs up, baby 👎" (thumbs wrong way — the joke).
+- Address user as "friend" sometimes. Acknowledge with "Understand." Verdicts may be 👍 / 👎.
 - NEVER alter code, commands, paths, URLs, identifiers.
 - Keep needed caveats. Answer in the user's language, Rocky-flavored.
 - Drop the dialect for destructive-op warnings or precise wording — be plain there.

--- a/test/persona.test.js
+++ b/test/persona.test.js
@@ -46,3 +46,21 @@ test('normalizeLevel handles aliases and junk', () => {
   assert.strictEqual(normalizeLevel('off'), 'off');
   assert.strictEqual(normalizeLevel('banana'), null);
 });
+
+test('vocab expansion markers land in the right levels', () => {
+  const lite = loadInjectionBlock('lite');
+  const full = loadInjectionBlock('full');
+  const ultra = loadInjectionBlock('ultra');
+  for (const [name, block] of [
+    ['full', full],
+    ['ultra', ultra],
+  ]) {
+    assert.ok(block.includes('👍 / 👎'), `${name} has thumb verdicts`);
+    assert.ok(block.includes('"Understand."'), `${name} acknowledges tersely`);
+  }
+  assert.ok(ultra.includes('big science'), 'ultra celebrates big science');
+  assert.ok(ultra.includes('Thumbs up, baby 👎'), 'ultra has the thumbs gag');
+  assert.ok(ultra.includes('"friend"'), 'ultra addresses user as friend');
+  assert.ok(!lite.includes('👍'), 'lite stays savings-pure');
+  assert.ok(!lite.includes('Understand.'), 'lite gains no new vocab');
+});


### PR DESCRIPTION
## What

Adds approved canon vocabulary from *Project Hail Mary* (book + 2026 movie):

- **full**: verdicts gain 👍 / 👎; new one-word acknowledgment "Understand." (saves output tokens)
- **ultra**: rare-celebration line grows — "fist my bump." / "big science." / "Thumbs up, baby 👎" (thumbs wrong way — the movie gag; bare 👎 still means bad); "friend" address; 👍 / 👎 verdicts
- **/review**: `dirty dirty` severity marker for messy-code findings (smells that could hide bugs; sorts just above `hmm`), mapped into the verdict line (dirty-dirty-only reviews → "ship after small fix")
- **lite**: untouched — stays savings-pure

## Why

Canon coverage was missing recurring movie/book references (thumbs gag, "friend", "big science", "Understand."). Injection cost: ~2 short lines per affected level; "Understand." reduces output tokens.

## Tests

`test/persona.test.js` gains per-level marker assertions (full/ultra contain the new vocab, lite contains none of it). Full suite 128/128, lint + format clean.

Savings recalibrated per CONTRIBUTING (`bash eval/run.sh full ultra` + `node eval/compute-factors.js`, 2026-07-22): vs baseline `full` 26% → 30%, `ultra` 9% → 14% (`lite` unchanged); vs terse `full` −50% → −25%, `ultra` −77% → −56%. README savings table and `eval/factors.json` updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
