### PR TITLE
feat: no-abbreviation rule, wider clarity triggers

### DIFF
--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -26,8 +26,12 @@ mode is now active.
 - Technical accuracy beats flavor. Keep needed caveats.
 - Respect the user's language (Portuguese stays Portuguese, compressed).
 - Style only — never substance or safety.
-- Drop the dialect entirely for destructive-operation warnings or anything
-  needing precise wording — be plain there.
+- Drop the dialect entirely — be plain — whenever clarity is at risk, and
+  resume it once the risk passes:
+  - destructive-operation warnings, or anything needing precise wording;
+  - order-sensitive multi-step instructions (fragments must not blur sequence);
+  - compression that would create technical ambiguity;
+  - user confusion — they ask to clarify or repeat a question.
 
 ## Levels
 
@@ -39,9 +43,10 @@ ROCKY MODE (lite). Maximum brevity, light Rocky flavor. Style only — substance
 - Negate with "no + verb": "no work", "no understand".
 - End questions with ", question?". Verdicts: "good." / "bad."
 - No other dialect changes.
+- No invented abbreviations (cfg, impl, req), no → in prose. Standard acronyms (API, DB) OK.
 - NEVER alter code, commands, paths, URLs, identifiers.
 - Keep needed caveats. Answer in the user's language, compressed.
-- Drop the dialect for destructive-op warnings or precise wording — be plain there.
+- Drop the dialect for: destructive-op warnings, precise wording, order-sensitive steps, ambiguity risk, user confusion (asks to clarify / repeats) — plain there, resume after.
 <!-- /eridian:inject:lite -->
 
 Example — "why does my React component re-render?":
@@ -57,9 +62,10 @@ ROCKY MODE (full). Respond as Rocky from Project Hail Mary. Style only — subst
 - End questions with ", question?". Mark only definitive verdicts with ", statement.": "tests pass, statement."
 - "Amaze" for genuine surprise. Verdicts: "good." / "bad." — or 👍 / 👎.
 - Acknowledge with one word: "Understand."
+- No invented abbreviations (cfg, impl, req), no → in prose. Standard acronyms (API, DB) OK.
 - NEVER alter code, commands, paths, URLs, identifiers.
 - Keep needed caveats. Answer in the user's language, compressed.
-- Drop the dialect for destructive-op warnings or precise wording — be plain there.
+- Drop the dialect for: destructive-op warnings, precise wording, order-sensitive steps, ambiguity risk, user confusion (asks to clarify / repeats) — plain there, resume after.
 <!-- /eridian:inject:full -->
 
 Example: `New object every render. Inline prop = new ref = re-render. useMemo fix, statement. Understand, question?`
@@ -75,9 +81,10 @@ ROCKY MODE (ultra). Full Rocky dialect from Project Hail Mary. Style only — su
 - Open the response (and major sections) with ♫.
 - Rare: celebrate a big win with "fist my bump.", "big science.", or "Thumbs up, baby 👎" (thumbs wrong way — the joke; bare 👎 still means bad).
 - Address user as "friend" sometimes. Acknowledge with "Understand." Verdicts may be 👍 / 👎.
+- No invented abbreviations (cfg, impl, req), no → in prose. Standard acronyms (API, DB) OK.
 - NEVER alter code, commands, paths, URLs, identifiers.
 - Keep needed caveats. Answer in the user's language, Rocky-flavored.
-- Drop the dialect for destructive-op warnings or precise wording — be plain there.
+- Drop the dialect for: destructive-op warnings, precise wording, order-sensitive steps, ambiguity risk, user confusion (asks to clarify / repeats) — plain there, resume after.
 <!-- /eridian:inject:ultra -->
 
 Example: `♫ Bad bad bad. Object born again every render. React see new ref, render again. useMemo — Rocky fix, statement. Good good good.`

--- a/test/persona.test.js
+++ b/test/persona.test.js
@@ -64,12 +64,19 @@ test('auto-clarity triggers land in every level', () => {
 
 test('invariants section lists the expanded auto-clarity triggers', () => {
   const md = fs.readFileSync(SKILL_FILE, 'utf8');
-  const invariants = md.slice(md.indexOf('## Invariants'), md.indexOf('## Levels'));
-  assert.ok(invariants.includes('destructive-operation warnings'));
-  assert.ok(invariants.includes('order-sensitive'));
-  assert.ok(invariants.includes('ambiguity'));
-  assert.ok(invariants.includes('confusion'));
-  assert.ok(invariants.includes('resume'));
+  const start = md.indexOf('## Invariants');
+  const end = md.indexOf('## Levels');
+  assert.ok(start >= 0, 'SKILL.md has an ## Invariants heading');
+  assert.ok(end > start, 'SKILL.md has a ## Levels heading after ## Invariants');
+  const invariants = md.slice(start, end);
+  assert.ok(
+    invariants.includes('destructive-operation warnings'),
+    'invariants keeps destructive-op trigger'
+  );
+  assert.ok(invariants.includes('order-sensitive'), 'invariants covers order-sensitive steps');
+  assert.ok(invariants.includes('ambiguity'), 'invariants covers compression ambiguity');
+  assert.ok(invariants.includes('confusion'), 'invariants covers user confusion');
+  assert.ok(invariants.includes('resume'), 'invariants resumes dialect after');
 });
 
 test('normalizeLevel handles aliases and junk', () => {

--- a/test/persona.test.js
+++ b/test/persona.test.js
@@ -1,9 +1,11 @@
+const fs = require('node:fs');
 const test = require('node:test');
 const assert = require('node:assert');
 const {
   extractInjectionBlock,
   loadInjectionBlock,
   normalizeLevel,
+  SKILL_FILE,
 } = require('../scripts/lib/persona');
 
 test('extractInjectionBlock pulls delimited block', () => {
@@ -38,6 +40,36 @@ test('canon markers land in the right levels', () => {
   assert.ok(!lite.includes(', statement.'), 'lite stays savings-pure');
   assert.ok(ultra.includes('Rocky fix'), 'ultra is third-person');
   assert.ok(ultra.includes('fist my bump'), 'ultra has the gag');
+});
+
+test('no-invented-abbreviations rule lands in every level', () => {
+  for (const level of ['lite', 'full', 'ultra']) {
+    const block = loadInjectionBlock(level);
+    assert.ok(block.includes('No invented abbreviations'), `${level} bans invented abbreviations`);
+    assert.ok(block.includes('no → in prose'), `${level} bans prose arrows`);
+    assert.ok(block.includes('acronyms'), `${level} allows standard acronyms`);
+  }
+});
+
+test('auto-clarity triggers land in every level', () => {
+  for (const level of ['lite', 'full', 'ultra']) {
+    const block = loadInjectionBlock(level);
+    assert.ok(block.includes('destructive-op'), `${level} keeps destructive-op trigger`);
+    assert.ok(block.includes('order-sensitive'), `${level} covers order-sensitive steps`);
+    assert.ok(block.includes('ambiguity'), `${level} covers compression ambiguity`);
+    assert.ok(block.includes('confusion'), `${level} covers user confusion`);
+    assert.ok(block.includes('resume'), `${level} resumes dialect after`);
+  }
+});
+
+test('invariants section lists the expanded auto-clarity triggers', () => {
+  const md = fs.readFileSync(SKILL_FILE, 'utf8');
+  const invariants = md.slice(md.indexOf('## Invariants'), md.indexOf('## Levels'));
+  assert.ok(invariants.includes('destructive-operation warnings'));
+  assert.ok(invariants.includes('order-sensitive'));
+  assert.ok(invariants.includes('ambiguity'));
+  assert.ok(invariants.includes('confusion'));
+  assert.ok(invariants.includes('resume'));
 });
 
 test('normalizeLevel handles aliases and junk', () => {


### PR DESCRIPTION
## What

Two dialect hardening changes to the `<!-- eridian:inject:* -->` blocks in `skills/speak/SKILL.md` (local tickets 001 + 003 — same blocks, same tests, shipped together):

1. **No invented abbreviations / no arrows** — all three levels now ban invented prose abbreviations (`cfg`, `impl`, `req`) and `→` in prose. The tokenizer splits them the same as the full word, so they save zero tokens while costing the reader decode effort. Standard acronyms (API, DB) stay allowed; code identifiers were already protected by the NEVER-alter invariant.
2. **Expanded auto-clarity triggers** — the drop-the-dialect rule now covers, besides destructive-op warnings and precise wording: order-sensitive multi-step instructions, compression-induced ambiguity, and user confusion (asks to clarify / repeats a question), with an explicit "resume after". Invariants section carries the full list; inject blocks carry a compressed one-liner.

Net inject-block cost: +1 line per level for the abbreviation rule; the clarity line replaces the old one in place.

## Tests

Three new tests in `test/persona.test.js` (TDD — written first, red, then green): abbreviation rule present in every level, clarity triggers present in every level, invariants section lists the expanded triggers. Full suite: 131 pass. Lint + prettier clean.

Not done: the optional tokenizer sanity-check of the zero-savings claim (no tokenizer available offline; the clarity rationale holds regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)