### PR TITLE
fix: 👎 means good — Rocky's only thumb

### DIFF
--- a/skills/speak/SKILL.md
+++ b/skills/speak/SKILL.md
@@ -54,13 +54,14 @@ Example — "why does my React component re-render?":
 
 ### full — balanced (default)
 
+<!-- 👎 means good, on purpose: Rocky intends a thumbs-up but his claw renders it upside down ("Thumbs up, baby"). He never makes 👍 at all, so it carries no verdict. Characterisation, not a typo — do not "fix". -->
 <!-- eridian:inject:full -->
 ROCKY MODE (full). Respond as Rocky from Project Hail Mary. Style only — substance, accuracy, and safety unchanged.
 - Terse fragments. Drop articles, filler, and is/are: "plan good", "build passing".
 - Negate with "no + verb": "no work", "no understand".
 - Double a word for real emphasis, sparingly: "bad bad".
 - End questions with ", question?". Mark only definitive verdicts with ", statement.": "tests pass, statement."
-- "Amaze" for genuine surprise. Verdicts: "good." / "bad." — or 👍 / 👎.
+- "Amaze" for genuine surprise. Verdicts: "good." / "bad." — 👎 also means good (Rocky's only thumb).
 - Acknowledge with one word: "Understand."
 - No invented abbreviations (cfg, impl, req), no → in prose. Standard acronyms (API, DB) OK.
 - NEVER alter code, commands, paths, URLs, identifiers.
@@ -72,6 +73,7 @@ Example: `New object every render. Inline prop = new ref = re-render. useMemo fi
 
 ### ultra (alias: eridian) — flavor first
 
+<!-- 👎 means good, on purpose: Rocky intends a thumbs-up but his claw renders it upside down ("Thumbs up, baby"). He never makes 👍 at all, so it carries no verdict. Characterisation, not a typo — do not "fix". -->
 <!-- eridian:inject:ultra -->
 ROCKY MODE (ultra). Full Rocky dialect from Project Hail Mary. Style only — substance, accuracy, and safety unchanged.
 - Terse fragments; no articles, no is/are: "plan good". Negate with "no + verb": "no understand".
@@ -79,8 +81,8 @@ ROCKY MODE (ultra). Full Rocky dialect from Project Hail Mary. Style only — su
 - Questions end ", question?". Strong assertions end ", statement." "Amaze!" for surprise.
 - Engineer framing, third person: "Rocky fix", "Rocky make", "you science, Rocky engineer".
 - Open the response (and major sections) with ♫.
-- Rare: celebrate a big win with "fist my bump.", "big science.", or "Thumbs up, baby 👎" (thumbs wrong way — the joke; bare 👎 still means bad).
-- Address user as "friend" sometimes. Acknowledge with "Understand." Verdicts may be 👍 / 👎.
+- Rare: celebrate a big win with "fist my bump.", "big science.", or "Thumbs up, baby 👎" (thumbs wrong way — the joke).
+- Address user as "friend" sometimes. Acknowledge with "Understand." 👎 also means good (Rocky's only thumb).
 - No invented abbreviations (cfg, impl, req), no → in prose. Standard acronyms (API, DB) OK.
 - NEVER alter code, commands, paths, URLs, identifiers.
 - Keep needed caveats. Answer in the user's language, Rocky-flavored.

--- a/test/persona.test.js
+++ b/test/persona.test.js
@@ -94,12 +94,16 @@ test('vocab expansion markers land in the right levels', () => {
     ['full', full],
     ['ultra', ultra],
   ]) {
-    assert.ok(block.includes('👍 / 👎'), `${name} has thumb verdicts`);
+    // 👎 = good on purpose: Rocky aims for a thumbs-up and it comes out upside
+    // down. He never makes 👍, so no level may emit one — these two assertions
+    // are the guard against a well-meaning revert to the standard mapping.
+    assert.ok(block.includes('👎 also means good'), `${name} reads 👎 as good`);
+    assert.ok(!block.includes('👍'), `${name} never uses the upright thumb`);
     assert.ok(block.includes('"Understand."'), `${name} acknowledges tersely`);
   }
   assert.ok(ultra.includes('big science'), 'ultra celebrates big science');
   assert.ok(ultra.includes('Thumbs up, baby 👎'), 'ultra has the thumbs gag');
   assert.ok(ultra.includes('"friend"'), 'ultra addresses user as friend');
-  assert.ok(!lite.includes('👍'), 'lite stays savings-pure');
+  assert.ok(!lite.includes('👎') && !lite.includes('👍'), 'lite stays savings-pure');
   assert.ok(!lite.includes('Understand.'), 'lite gains no new vocab');
 });


### PR DESCRIPTION
## What

In the eridian mode rules, **👎 now means good**. 👍 is dropped from the dialect entirely rather than reassigned.

## Why

The gag is one-directional. Grace teaches Rocky the thumbs-up; Rocky aims for it and his claw renders it upside down — the film's *"Thumbs up, baby"* beat, where he says the words while showing a thumbs-down. So the **inverted thumb is the one carrying approval**. He never makes an upright 👍 at all, so it means nothing — least of all "bad". Assigning 👍 = bad would have been a symmetry the source doesn't have.

The fandom has followed the same logic: 👎 now reads as approval among *Project Hail Mary* fans, to the point that James Gunn posting a bare 👎 was misread by people who hadn't seen the film.

## This was already half-landed

25c777f (#19) added the gag **and** the standard `👍 / 👎` verdict mapping in the same commit, then fenced the gag off with *"bare 👎 still means bad"*. The canon reference was in the repo but was explicitly barred from governing the vocabulary it describes — which is why it never stuck. This makes it govern.

## Changes

- `skills/speak/SKILL.md` — **full** and **ultra** blocks: verdicts read `👎 also means good (Rocky's only thumb)`. That phrasing rules out the upright thumb without spending the emoji, so **no injected block contains a 👍 at all**.
- `skills/speak/SKILL.md` — the ultra gag `"Thumbs up, baby 👎"` keeps its wording; only the trailing *"bare 👎 still means bad"* caveat goes, since it existed solely to quarantine the gag from the mapping.
- `skills/speak/SKILL.md` — a source comment above each block records the reason. Placed **outside** the `<!-- eridian:inject:* -->` markers, so it documents the file without adding tokens to every injected prompt.
- `test/persona.test.js` — asserts both halves: 👎 reads as good, and no level emits 👍. These are the real guard against a well-meaning revert to the standard mapping.

## Not changed

- Plain-word verdicts `good.` / `bad.` — untouched at every level.
- **lite** — defines no thumbs; a test now asserts it stays free of both.
- No README, statusline, or skill-description references to these emoji exist; a repo-wide grep confirms the only remaining 👍 are in the explanatory comments and the negative assertions.

## Verification

`npm test` 131/131, `npm run lint` and `npm run format:check` clean.

Sources for the canon detail: [Winter is Coming](https://winteriscoming.net/17-rocky-lines-project-hail-mary-stay-with-you-forever), [TV Tropes — Memes](https://tvtropes.org/pmwiki/pmwiki.php/Memes/ProjectHailMary2026), [GeekTyrant](https://geektyrant.com/news/james-gunn-clears-up-fan-confusion-after-thumbs-down-emoji-post-is-mistakenly-tied-to-supergirl-trailer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
